### PR TITLE
Allow to add multiple configuration file to configmap

### DIFF
--- a/pkg/apis/logging/v1alpha1/loggingplugin_types.go
+++ b/pkg/apis/logging/v1alpha1/loggingplugin_types.go
@@ -62,8 +62,8 @@ type Parameter struct {
 // GetValue for a Parameter
 func (p Parameter) GetValue(namespace string, client client.Client) (string, string) {
 	if p.ValueFrom != nil {
-		value, error := p.ValueFrom.GetValue(namespace, client)
-		if error != nil {
+		value, err := p.ValueFrom.GetValue(namespace, client)
+		if err != nil {
 			return "", ""
 		}
 		return p.Name, value

--- a/pkg/resources/plugins/plugins.go
+++ b/pkg/resources/plugins/plugins.go
@@ -39,11 +39,12 @@ type Reconciler struct {
 }
 
 // New creates a new FPlugin reconciler
-func New(client client.Client, plugin *loggingv1alpha1.Plugin) *Reconciler {
+func New(client client.Client, pluginList *loggingv1alpha1.PluginList, namespace string) *Reconciler {
 	return &Reconciler{
 		PluginReconciler: resources.PluginReconciler{
-			Client: client,
-			Plugin: plugin,
+			Client:     client,
+			Namespace:  namespace,
+			PluginList: pluginList,
 		},
 	}
 }

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -25,8 +25,9 @@ import (
 
 // PluginReconciler reconciler struct for plugin
 type PluginReconciler struct {
-	Client client.Client
-	Plugin *loggingv1alpha1.Plugin
+	Client     client.Client
+	Namespace  string
+	PluginList *loggingv1alpha1.PluginList
 }
 
 // FluentdReconciler reconciler struct for fluentd
@@ -51,3 +52,6 @@ type Resource func() runtime.Object
 
 // ResourceVariation redeclaration of function with parameter and return type kubernetes Object
 type ResourceVariation func(t string) runtime.Object
+
+// ResourceWithLog redeclaration of function with logging parameter and return type kubernetes Object
+type ResourceWithLog func(log logr.Logger) runtime.Object

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -22,19 +22,11 @@ import (
 )
 
 // PluginsObjectMeta creates an objectMeta for resource plugin
-func PluginsObjectMeta(name string, labels map[string]string, plugin *loggingv1alpha1.Plugin) metav1.ObjectMeta {
+func PluginsObjectMeta(name string, labels map[string]string, namespace string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
 		Name:      name,
-		Namespace: plugin.Namespace,
+		Namespace: namespace,
 		Labels:    labels,
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: plugin.APIVersion,
-				Kind:       plugin.Kind,
-				Name:       plugin.Name,
-				UID:        plugin.UID,
-			},
-		},
 	}
 	return o
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,6 +18,9 @@ package util
 
 // MergeLabels merges two map[string]string map
 func MergeLabels(l map[string]string, l2 map[string]string) map[string]string {
+	if len(l) == 0 {
+		l = map[string]string{}
+	}
 	for lKey, lValue := range l2 {
 		l[lKey] = lValue
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the ability to use multiple plugin crs. Now if multiple plugin crs are submitted the created ConfigMap will hold all cr related config instead of overwriting it.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)