### PR TITLE
Elasticsearch ssl verify check parameter support

### DIFF
--- a/deploy/crds/logging_v1alpha1_fluentd_cr.yaml
+++ b/deploy/crds/logging_v1alpha1_fluentd_cr.yaml
@@ -13,7 +13,7 @@ spec:
   tls:
     enabled: false
   image:
-    tag: "v1.1.4"
+    tag: "v1.4"
     repository: "banzaicloud/fluentd"
     pullPolicy: "IfNotPresent"
   volumeModImage:

--- a/deploy/crds/logging_v1alpha1_fluentd_cr.yaml
+++ b/deploy/crds/logging_v1alpha1_fluentd_cr.yaml
@@ -13,7 +13,7 @@ spec:
   tls:
     enabled: false
   image:
-    tag: "v1.4"
+    tag: "v1.4.2"
     repository: "banzaicloud/fluentd"
     pullPolicy: "IfNotPresent"
   volumeModImage:

--- a/docs/plugins/elasticsearch.md
+++ b/docs/plugins/elasticsearch.md
@@ -7,6 +7,7 @@
 | host | - |  |
 | port | - |  |
 | scheme | scheme |  |
+| sslVerify | true |  |
 | logstashFormat | true |  |
 | logstashPrefix | logstash |  |
 | bufferPath | /buffers/elasticsearch |  |
@@ -29,13 +30,16 @@
   host {{ .host }}
   port {{ .port }}
   scheme  {{ .scheme }}
+  {{- if .sslVerify }}
+  ssl_verify {{ .sslVerify }}
+  {{- end}}
   logstash_format {{ .logstashFormat }}
   logstash_prefix {{ .logstashPrefix }}
   reconnect_on_error true
   {{- if .user }}
   user {{ .user }}
   {{- end}}
-  {{- if .password }}
+  {{- if .password }} 
   password {{ .password }}
   {{- end}}
   <buffer tag, time>

--- a/docs/plugins/elasticsearch.md
+++ b/docs/plugins/elasticsearch.md
@@ -8,6 +8,7 @@
 | port | - |  |
 | scheme | scheme |  |
 | sslVerify | true |  |
+| sslVersion | TLSv1_2 |  |
 | logstashFormat | true |  |
 | logstashPrefix | logstash |  |
 | bufferPath | /buffers/elasticsearch |  |
@@ -32,6 +33,9 @@
   scheme  {{ .scheme }}
   {{- if .sslVerify }}
   ssl_verify {{ .sslVerify }}
+  {{- end}}
+  {{- if .sslVersion }}
+  ssl_version {{ .sslVersion }}
   {{- end}}
   logstash_format {{ .logstashFormat }}
   logstash_prefix {{ .logstashPrefix }}

--- a/docs/plugins/elasticsearch.md
+++ b/docs/plugins/elasticsearch.md
@@ -39,7 +39,7 @@
   {{- if .user }}
   user {{ .user }}
   {{- end}}
-  {{- if .password }} 
+  {{- if .password }}
   password {{ .password }}
   {{- end}}
   <buffer tag, time>

--- a/pkg/resources/plugins/elasticsearch.go
+++ b/pkg/resources/plugins/elasticsearch.go
@@ -11,6 +11,7 @@ var ElasticsearchDefaultValues = map[string]string{
 	"logstashPrefix":     "logstash",
 	"scheme":             "scheme",
 	"sslVerify":          "true",
+	"sslVersion":         "TLSv1_2",
 	"chunkLimit":         "2M",
 	"queueLimit":         "8",
 	"timekey":            "1h",
@@ -36,6 +37,9 @@ const ElasticsearchTemplate = `
   scheme  {{ .scheme }}
   {{- if .sslVerify }}
   ssl_verify {{ .sslVerify }}
+  {{- end}}
+  {{- if .sslVersion }}
+  ssl_version {{ .sslVersion }}
   {{- end}}
   logstash_format {{ .logstashFormat }}
   logstash_prefix {{ .logstashPrefix }}

--- a/pkg/resources/plugins/elasticsearch.go
+++ b/pkg/resources/plugins/elasticsearch.go
@@ -10,6 +10,7 @@ var ElasticsearchDefaultValues = map[string]string{
 	"logstashFormat":     "true",
 	"logstashPrefix":     "logstash",
 	"scheme":             "scheme",
+	"sslVerify":          "true",
 	"chunkLimit":         "2M",
 	"queueLimit":         "8",
 	"timekey":            "1h",
@@ -33,6 +34,9 @@ const ElasticsearchTemplate = `
   host {{ .host }}
   port {{ .port }}
   scheme  {{ .scheme }}
+  {{- if .sslVerify }}
+  ssl_verify {{ .sslVerify }}
+  {{- end}}
   logstash_format {{ .logstashFormat }}
   logstash_prefix {{ .logstashPrefix }}
   reconnect_on_error true


### PR DESCRIPTION
### Version Update:

**Fluentd**
-  'fluentd' version '1.1.2' ->  'fluentd' version '1.4.2'

**Plugins**
- fluent-plugin-s3 1.1.7 -> 1.1.9
- fluent-plugin-rewrite-tag-filter 2.1.1 -> 2.2.0
- fluent-plugin-prometheus 1.2.1 -> 1.3.0
- fluent-plugin-oss 0.0.1 -> 0.0.2
- fluent-plugin-kubernetes_metadata_filter 2.1.5 -> 2.1.6
- fluent-plugin-elasticsearch 2.12.2 -> 3.4.1

### New Parameter Support:
**Elasticsearch Plugin**
- ssl_version
- ssl_verify
[more info](https://github.com/uken/fluent-plugin-elasticsearch#user-password-path-scheme-ssl_verify
)

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0



