### PR TITLE
added documentation for #78 and 213e9a8

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ $ helm install banzaicloud-stable/logging-operator
 $ helm install  \
 --set bucketName='<Mybucket>' \
 --set region='<S3_REGION>' \
+--set endpoint='<S3_ENDPOINT>' \
 --set awsCredentialsAccess.enabled=true \
 --set awsCredentialsAccess.secret.awsAccessValue='<AWS_ACCESS_KEY_ID>' \
 --set awsCredentialsAccess.secret.awsSecretValue='<AWS_SECRET_ACCESS_KEY>' \
@@ -96,7 +97,7 @@ banzaicloud-stable/s3-output
 
 > There is **no** need to encode base64 these values.  
 
-#### Install Nginx Demo app 
+#### Install Nginx Demo app
 ```bash
 $ helm install banzaicloud-stable/nginx-logging-demo
 ```
@@ -111,7 +112,7 @@ kubectl create -f deploy/crds/logging_v1alpha1_fluentbit_crd.yaml
 kubectl create -f deploy/crds/logging_v1alpha1_fluentd_crd.yaml
 
 # If RBAC enabled create the required resources
-kubectl create -f deploy/clusterrole.yaml 
+kubectl create -f deploy/clusterrole.yaml
 kubectl create -f deploy/clusterrole_binding.yaml
 kubectl create -f deploy/service_account.yaml
 
@@ -189,6 +190,8 @@ spec:
           value: logging-bucket
         - name: s3_region
           value: ap-northeast-1
+        - name: s3_endpoint
+          value: https://s3.amazonaws.com
 ```
 
 ---
@@ -211,7 +214,7 @@ $ helm install --name elasticsearch-operator es-operator/elasticsearch-operator 
 $ helm install --name elasticsearch es-operator/elasticsearch --set kibana.enabled=True --set cerebro.enabled=True
 $ helm install --name loggingo banzaicloud-stable/logging-operator
 ```
-> [Elasticsearch Operator Documentation](https://github.com/upmc-enterprises/elasticsearch-operator) 
+> [Elasticsearch Operator Documentation](https://github.com/upmc-enterprises/elasticsearch-operator)
 
 #### Install Nginx Demo chart
 ```bash

--- a/docs/plugins/s3.md
+++ b/docs/plugins/s3.md
@@ -9,6 +9,7 @@
 | instance_profile_port | - |  |
 | aws_key_id | - |  |
 | aws_sec_key | - |  |
+| s3_endpoint | - |  |
 | s3_bucket | - |  |
 | s3_region | - |  |
 | s3_object_key_format | %{path}%{time_slice}_%{index}.%{file_extension} |  |


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Additional documentation for #78 (213e9a8) and [banzaicloud/banzai-charts#528](https://github.com/banzaicloud/banzai-charts/pull/528)
| License         | Apache 2.0

### What's in this PR?
I added additional documentation for the s3_endpoint variable and will be submitting another PR to the [banzaicloud/banzai-charts](https://github.com/banzaicloud/banzai-chart).

### Why?
I want to use Wasabi instead of Amazon, and noticed the feature existed but appeared undocumented.