### PR TITLE
Add reserve_data option to ParserFilterTemplate

### DIFF
--- a/docs/plugins/parser.md
+++ b/docs/plugins/parser.md
@@ -6,6 +6,7 @@
 | format | - |  |
 | timeFormat | - |  |
 | keyName | log |  |
+| reserveData | false |  |
 ## Plugin template
 ```
 <filter {{ .pattern }}.** >
@@ -13,6 +14,7 @@
   format {{ .format }}
   time_format {{ .timeFormat }}
   key_name {{ .keyName }}
+  reserve_data {{ .reserveData }}
 </filter>
 
 ```

--- a/pkg/resources/plugins/parser.go
+++ b/pkg/resources/plugins/parser.go
@@ -21,7 +21,8 @@ const ParserFilter = "parser"
 
 // ParserFilterDefaultValues for parser plugin
 var ParserFilterDefaultValues = map[string]string{
-	"keyName": "log",
+	"keyName":     "log",
+	"reserveData": "false",
 }
 
 // ParserFilterTemplate for parser plugin
@@ -31,5 +32,6 @@ const ParserFilterTemplate = `
   format {{ .format }}
   time_format {{ .timeFormat }}
   key_name {{ .keyName }}
+  reserve_data {{ .reserveData }}
 </filter>
 `


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Adds the reserve_data option to the ParserFilter template.


### Why?
I want to retain Kubernetes (and other) metadata fields from the event for analysis.

### Checklist
- [X] Implementation tested (with at least one cloud provider)
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline (TODO)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)
