### PR TITLE
Add Kube_Tag_Prefixparameter for fluent-bit config

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -40,6 +40,7 @@ var fluentBitConfigTemplate = `
 [FILTER]
     Name                kubernetes
     Match               kubernetes.*
+    Kube_Tag_Prefix     kubernetes.var.log.containers.
     Kube_URL            https://kubernetes.default.svc:443
     Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | yes
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
Add extra parameter to fluent-bit configuration.

### Why?
Without this prefix fluent-bit won't attach Kubernetes metadata to log.