### PR TITLE
Do not remove the generated app-config if fluentd resource updated

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -17,15 +17,23 @@
 package fluentd
 
 import (
+	"context"
+
 	"github.com/banzaicloud/logging-operator/pkg/resources/templates"
 	"github.com/banzaicloud/logging-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (r *Reconciler) appconfigMap() runtime.Object {
-	return &corev1.ConfigMap{
-		ObjectMeta: templates.FluentdObjectMeta(appConfigMapName, util.MergeLabels(r.Fluentd.Labels, labelSelector), r.Fluentd),
-		Data:       map[string]string{},
+	current := &corev1.ConfigMap{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Fluentd.Namespace, Name: appConfigMapName}, current)
+	if err != nil {
+		return &corev1.ConfigMap{
+			ObjectMeta: templates.FluentdObjectMeta(appConfigMapName, util.MergeLabels(r.Fluentd.Labels, labelSelector), r.Fluentd),
+			Data:       map[string]string{},
+		}
 	}
+	return current
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   |no|
| License         | Apache 2.0


### What's in this PR?
This PR fixes the reconcile loop so it will not delete the already configured fluent Configmap if fluentd updated.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] Related Helm chart(s) updated (if needed)