### PR TITLE
Fix kubernetes metadata forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ kubectl create -f deploy/crds/logging_v1alpha1_fluentd_cr.yaml
 | [Grafana Loki](./docs/plugins/loki.md)          | Output | Transfer logs to Loki                                                     | Testing | [0.2](https://github.com/banzaicloud/fluent-plugin-kubernetes-loki/releases/tag/v0.2)    |
 | [ElasticSearch](./docs/plugins/parser.md)       | Output | Send your logs to Elasticsearch                                           |    GA   | [3.5.2](https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v3.5.2)         |
 | [HDFS](https://docs.fluentd.org/output/webhdfs) | Output | Fluentd output plugin to write data into Hadoop HDFS over WebHDFS/HttpFs. |    GA   | [1.2.3](https://github.com/fluent/fluent-plugin-webhdfs/releases/tag/v1.2.3)             |
-| Kubernetes Metadata Filter                      | Filter | Filter plugin to add Kubernetes metadata                                  |    GA   | [2.2.0](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter)           |
 | [Parser](./docs/plugins/parser.md)              | Parser | Parse logs with parser plugin                                             |    GA   |                                                                                          |
 ---
 

--- a/docs/examples/es.md
+++ b/docs/examples/es.md
@@ -15,7 +15,8 @@ $ helm repo update
 ```bash
 $ helm install --name elasticsearch-operator es-operator/elasticsearch-operator --set rbac.enabled=True
 $ helm install --name elasticsearch es-operator/elasticsearch --set kibana.enabled=True --set cerebro.enabled=True
-$ helm install --name loggingo banzaicloud-stable/logging-operator
+$ helm install --name logging banzaicloud-stable/logging-operator
+$ helm install --name fluent banzaicloud-stable/logging-operator-fluent
 ```
 > [Elasticsearch Operator Documentation](https://github.com/upmc-enterprises/elasticsearch-operator)
 

--- a/docs/plugins/parser.md
+++ b/docs/plugins/parser.md
@@ -6,7 +6,8 @@
 | format | - |  |
 | timeFormat | - |  |
 | keyName | log |  |
-| reserveData | false |  |
+| reserveData | true |  |
+| removeKeyNameField | log |  |
 ## Plugin template
 ```
 <filter {{ .pattern }}.** >
@@ -15,6 +16,7 @@
   time_format {{ .timeFormat }}
   key_name {{ .keyName }}
   reserve_data {{ .reserveData }}
+  remove_key_name_field {{ .removeKeyNameField }}
 </filter>
 
 ```

--- a/pkg/resources/plugins/parser.go
+++ b/pkg/resources/plugins/parser.go
@@ -21,8 +21,9 @@ const ParserFilter = "parser"
 
 // ParserFilterDefaultValues for parser plugin
 var ParserFilterDefaultValues = map[string]string{
-	"keyName":     "log",
-	"reserveData": "false",
+	"keyName":            "log",
+	"reserveData":        "true",
+	"removeKeyNameField": "true",
 }
 
 // ParserFilterTemplate for parser plugin
@@ -33,5 +34,6 @@ const ParserFilterTemplate = `
   time_format {{ .timeFormat }}
   key_name {{ .keyName }}
   reserve_data {{ .reserveData }}
+  remove_key_name_field {{ .removeKeyNameField }}
 </filter>
 `


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
This PR enables kubernetes metadata forwarding with the fluentd parser plugin by default to send metadata along with the parsed fields.

The fluentd plugin "Kubernetes Metadata Filter" has been removed from the readme to avoid confusion since it's not used and not required for metadata collection and forwarding. Kubernetes metadata is collected and populated into log items in fluent-bit. 

### Why?
Forwarding Kubernetes metadata should be the default option as it is already collected by fluent-bit. 

### Additional context
In case the parsed log fields overlap with the kubernetes fields, the kubernetes fields will win.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
