### PR TITLE
Add `path` argument to s3 plugin

### DIFF
--- a/docs/plugins/s3.md
+++ b/docs/plugins/s3.md
@@ -18,6 +18,7 @@
 | bufferTimeWait | 10m |  |
 | timekey_use_utc | true |  |
 | format | json |  |
+| path | logs/${tag}/%Y/%m/%d/ |  |
 ## Plugin template
 ```
 <match {{ .pattern }}.** >
@@ -49,7 +50,7 @@
   {{- end }}
   store_as gzip_command
 
-  path logs/${tag}/%Y/%m/%d/
+  path {{ .path }}
   s3_object_key_format {{ .s3_object_key_format }}
 
   # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / s3_object_key_format,

--- a/pkg/resources/plugins/s3.go
+++ b/pkg/resources/plugins/s3.go
@@ -27,6 +27,7 @@ var S3DefaultValues = map[string]string{
 	"format":               "json",
 	"timekey_use_utc":      "true",
 	"s3_object_key_format": "%{path}%{time_slice}_%{index}.%{file_extension}",
+	"path":                 "logs/${tag}/%Y/%m/%d/",
 }
 
 // S3Template for Amazaon S3 output plugin
@@ -60,7 +61,7 @@ const S3Template = `
   {{- end }}
   store_as gzip_command
 
-  path logs/${tag}/%Y/%m/%d/
+  path {{ .path }}
   s3_object_key_format {{ .s3_object_key_format }}
 
   # if you want to use ${tag} or %Y/%m/%d/ like syntax in path / s3_object_key_format,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
This adds the ability to specify that path in s3 to send the logs. This preserves the existing path as the default.


### Why?
You may, in the case of buckets shared with other types of artifacts, want to change exactly where the logs get stored.


### Additional context
Testing:

* Built a docker image with my change
* redeployed logging operator
* Modified `s3-output` helm chart with the configuration
* Pushed a custom logger path

As far as edge cases, if there isn't a trailing `/` at the end of the path, the `path` will not be treated as a directory, but instead a prefix for the file. This appears to be a quirk of the fluentd s3 output plugin, not the operator itself.

If approved, I can make the changes in the upstream helm chart as well.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)