### PR TITLE
v2: Indent psp rbac groups correctly

### DIFF
--- a/charts/logging-operator/templates/rbac.yaml
+++ b/charts/logging-operator/templates/rbac.yaml
@@ -78,14 +78,14 @@ rules:
     verbs:
       - "*"
   {{- if .Values.rbac.psp.enabled }}
-- apiGroups:
-    - extensions
-  resources:
-    - podsecuritypolicies
-  resourceNames:
-    - psp.logging-operator
-  verbs:
-    - use
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - psp.logging-operator
+    verbs:
+      - use
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This fixes the logging operator helm charts, which are currently broken if you enable pod security policies.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If you enable pod security policies, a helm install fails.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
