### PR TITLE
Mark `path` argument as required

### DIFF
--- a/docs/plugins/outputs/buffer.md
+++ b/docs/plugins/outputs/buffer.md
@@ -3,7 +3,7 @@
 |---|---|---|---|---|
 | type | string | No | - | Fluentd core bundles memory and file plugins. 3rd party plugins are also available when installed.<br> |
 | tags | string | No |  tag,time | When tag is specified as buffer chunk key, output plugin writes events into chunks separately per tags. <br> |
-| path | string | No | - | The path where buffer chunks are stored. The '*' is replaced with random characters. This parameter is required.<br> |
+| path | string | Yes | - | The path where buffer chunks are stored. The '*' is replaced with random characters. This parameter is required.<br> |
 | chunk_limit_size | string | No | - | The max size of each chunks: events will be written into chunks until the size of chunks become this size<br> |
 | chunk_limit_records | int | No | - | The max number of events that each chunks can store in it<br> |
 | total_limit_size | string | No | - | The size limitation of this buffer plugin instance. Once the total size of stored buffer reached this threshold, all append operations will fail with error (and data will be lost)<br> |


### PR DESCRIPTION
Mark `path` as required, since it's required for the configuration check to pass

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Documentation change marking `path` in the `buffer` section required


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It's required, and the config check will fail to execute without it

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested (with at least one cloud provider)
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
