### PR TITLE
bump image and chart versions to 1.0.0 as the last feature release of the current development line

### DIFF
--- a/charts/logging-operator-fluent/Chart.yaml
+++ b/charts/logging-operator-fluent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Logging operator CR for Fluentd and Fluent-bit.
 name: logging-operator-fluent
-version: 0.3.3
+version: 1.0.0
 home: https://github.com/banzaicloud/logging-operator
 icon: https://banzaicloud.com/img/banzai-cloud-logo.png
 keywords:

--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Logging operator for Kubernetes based on Fluentd and Fluent-bit.
 name: logging-operator
-version: 0.3.3
-appVersion: 0.2.2
+version: 1.0.0
+appVersion: 1.0.0
 home: https://github.com/banzaicloud/logging-operator
 icon: https://banzaicloud.com/img/banzai-cloud-logo.png
 keywords:

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -45,7 +45,7 @@ The following tables lists the configurable parameters of the logging-operator c
 |                      Parameter                      |                        Description                     |             Default            |
 | --------------------------------------------------- | ------------------------------------------------------ | ------------------------------ |
 | `image.repository`                                  | Container image repository                             | `banzaicloud/logging-operator` |
-| `image.tag`                                         | Container image tag                                    | `0.2.2`                        |
+| `image.tag`                                         | Container image tag                                    | `1.0.0`                        |
 | `image.pullPolicy`                                  | Container pull policy                                  | `IfNotPresent`                 |
 | `nameOverride`                                      | Override name of app                                   | ``                             |
 | `fullnameOverride`                                  | Override full name of app                              | ``                             |

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/logging-operator
-  tag: 0.2.2
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: logging-operator
           # Replace this with the built image name
-          image: banzaicloud/logging-operator:0.2.2
+          image: banzaicloud/logging-operator:1.0.0
           command:
           - logging-operator
           imagePullPolicy: IfNotPresent

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -2,7 +2,7 @@
 
 set -eufo pipefail
 
-SCRIPT_PATH="$(dirname "$(readlink -f "$0")")"
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 BUCKET='minio/logs'
 
 function main()
@@ -22,7 +22,7 @@ function helm_deploy_logging_operator()
         --wait \
         --name logging-operator \
         --set image.tag='local' \
-        banzaicloud-stable/logging-operator
+        charts/logging-operator
 }
 
 function helm_deploy_logging_operator_fluent()
@@ -30,7 +30,7 @@ function helm_deploy_logging_operator_fluent()
     helm install \
         --wait \
         --name logging-operator-fluent \
-        banzaicloud-stable/logging-operator-fluent
+        charts/logging-operator-fluent
 }
 
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #133 
| License         | Apache 2.0

### What's in this PR?
- support tls type secret
- support configuring tolerations

### Additional context
this is a final feature release for the current development line which is now considered 1.0.0, but development will continue on version 2 (v2 branch), which will be merged into the master branch soon.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (with at least one cloud provider)
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

