### PR TITLE
Fix fluentd config template and error handling #240

### DIFF
--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -24,7 +24,7 @@ var fluentdInputTemplate = `
 # Enable RPC endpoint (this allows to trigger config reload without restart)
 <system>
   rpc_endpoint 127.0.0.1:24444
-  log_level {{ default .LogLevel "error" }}
+  log_level {{ .LogLevel }}
 </system>
 
 # Prometheus monitoring


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #240 
| License         | Apache 2.0


### What's in this PR?
Fix an error introduced during adding configurable error level in fluentd.

### Why?
The error causes the monitoring integration be disfunctional in the default case.

### Additional context
Added proper error handling to the `generateConfig` method.

