### PR TITLE
Manage desired state for resources having limited update capability (statefulset, daemonset)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ manager: generate fmt vet
 run: generate fmt vet
 	go run ./main.go --verbose
 
+# remote debug
+debug: manager
+	dlv --listen=:40000 --log --headless=true --api-version=2 exec bin/manager -- $(ARGS)
+
 # Install CRDs into a cluster
 install: manifests
 	kubectl apply -f config/crd/bases

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -36,6 +36,13 @@ spec:
           properties:
             controlNamespace:
               type: string
+            enableRecreateWorkloadOnImmutableFieldChange:
+              description: EnableRecreateWorkloadOnImmutableFieldChange enables the
+                operator to recreate the fluentbit daemonset and the fluentd statefulset
+                (and possibly other resource in the future) in case there is a change
+                in an immutable field that otherwise couldn't be managed with a simple
+                update.
+              type: boolean
             flowConfigCheckDisabled:
               type: boolean
             flowConfigOverride:

--- a/config/samples/logging_v1alpha2_logging_pvc.yaml
+++ b/config/samples/logging_v1alpha2_logging_pvc.yaml
@@ -4,5 +4,14 @@ metadata:
   name: defaultlogging
 spec:
   fluentd: {}
+    bufferStorageVolume:
+      pvc:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+          volumeMode: Filesystem
   fluentbit: {}
   controlNamespace: default

--- a/config/samples/logging_v1alpha2_logging_pvc.yaml
+++ b/config/samples/logging_v1alpha2_logging_pvc.yaml
@@ -3,7 +3,7 @@ kind: Logging
 metadata:
   name: defaultlogging
 spec:
-  fluentd: {}
+  fluentd:
     bufferStorageVolume:
       pvc:
         spec:

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/banzaicloud/logging-operator/pkg/k8sutil"
 	"github.com/banzaicloud/logging-operator/pkg/resources/templates"
 	"github.com/banzaicloud/logging-operator/pkg/sdk/util"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +56,7 @@ func (r *Reconciler) daemonSet() (runtime.Object, k8sutil.DesiredState, error) {
 		templates.Annotate(podMeta, "checksum/config", fmt.Sprintf("%x", h.Sum(nil)))
 	}
 
-	return &appsv1.DaemonSet{
+	desired := &appsv1.DaemonSet{
 		ObjectMeta: meta,
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: util.MergeLabels(r.Logging.Spec.FluentbitSpec.Labels, r.getFluentBitLabels())},
@@ -92,7 +93,9 @@ func (r *Reconciler) daemonSet() (runtime.Object, k8sutil.DesiredState, error) {
 				},
 			},
 		},
-	}, k8sutil.StatePresent, nil
+	}
+
+	return desired, k8sutil.StatePresent, nil
 }
 
 func (r *Reconciler) generateVolumeMounts() (v []corev1.VolumeMount) {

--- a/pkg/resources/fluentbit/fluentbit.go
+++ b/pkg/resources/fluentbit/fluentbit.go
@@ -69,7 +69,7 @@ type Reconciler struct {
 func New(client client.Client, logger logr.Logger, logging *v1beta1.Logging) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
-		GenericResourceReconciler: k8sutil.NewReconciler(client, logger),
+		GenericResourceReconciler: k8sutil.NewReconciler(client, logger, logging),
 	}
 }
 
@@ -94,10 +94,13 @@ func (r *Reconciler) Reconcile() (*reconcile.Result, error) {
 		if o == nil {
 			return nil, errors.Errorf("Reconcile error! Resource %#v returns with nil object", factory)
 		}
-		err = r.ReconcileResource(o, state)
+		result, err := r.ReconcileResource(o, state)
 		if err != nil {
 			return nil, errors.WrapWithDetails(err,
 				"failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
+		}
+		if result != nil {
+			return result, nil
 		}
 	}
 

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -38,10 +38,12 @@ func (r *Reconciler) statefulset() (runtime.Object, k8sutil.DesiredState, error)
 			},
 		}
 	}
-	return &appsv1.StatefulSet{
+	desired := &appsv1.StatefulSet{
 		ObjectMeta: r.FluentdObjectMeta(StatefulSetName),
 		Spec:       spec,
-	}, k8sutil.StatePresent, nil
+	}
+
+	return desired, k8sutil.StatePresent, nil
 }
 
 func (r *Reconciler) statefulsetSpec() *appsv1.StatefulSetSpec {

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -35,6 +35,12 @@ type LoggingSpec struct {
 	FluentdSpec             *FluentdSpec   `json:"fluentd,omitempty"`
 	WatchNamespaces         []string       `json:"watchNamespaces,omitempty"`
 	ControlNamespace        string         `json:"controlNamespace"`
+
+	// EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the
+	// fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future)
+	// in case there is a change in an immutable field
+	// that otherwise couldn't be managed with a simple update.
+	EnableRecreateWorkloadOnImmutableFieldChange bool `json:"enableRecreateWorkloadOnImmutableFieldChange,omitempty"`
 }
 
 // LoggingStatus defines the observed state of Logging
@@ -141,11 +147,10 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 		if copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim == nil {
 			copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim = &PersistentVolumeClaim{
 				PersistentVolumeClaimSpec: copy.Spec.FluentdSpec.FluentdPvcSpec,
-				PersistentVolumeSource: v1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "fluentd-buffer",
-					ReadOnly:  false,
-				},
 			}
+		}
+		if copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName == "" {
+			copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName = "fluentd-buffer"
 		}
 		if copy.Spec.FluentdSpec.VolumeModImage.Repository == "" {
 			copy.Spec.FluentdSpec.VolumeModImage.Repository = "busybox"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #249 
| License         | Apache 2.0


### What's in this PR?
Support an for an optional desired state hook to be called before update. It will receive the current state and can alter the desired object if necessary. E.g. service.spec.clusterIP can be set to the current  value to avoid errors when updating with an empty value.

Add support for removing objects if they cannot be updated (similar to how the prometheus operator manages statefulset updates). 

Add and fix some docs.
Fix pvc default config for fluentd.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
