### PR TITLE
Add support for Priority Classes for fluentd and fluentbit

### DIFF
--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -24,6 +24,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.tag`                               | Fluentbit container image tag                          | `1.3.2`                                                    |
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`                                        |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                                             |
+| `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                 | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                                                       |
 | `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.7.4-alpine-8`                                          |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `banzaicloud/fluentd`                                      |
@@ -39,3 +40,4 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentd.fluentdPvcSpec.resources.storageClassName` | Fluentd persistence volume storageclass                | `"""`                                                      |
 | `fluentd.tolerations`                               | Tolerations for fluentd statefulset                    | none                                                       |
 | `fluentd.nodeSelector`                              | Node selector for fluentd pods                         | none                                                       |
+| `fluentd.podPriorityClassName`                      | Priority class name for fluentd pods                   | none                                                       |

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -536,6 +536,8 @@ spec:
                   type: string
                 parser:
                   type: string
+                podPriorityClassName:
+                  type: string
                 position_db:
                   properties:
                     emptyDir:
@@ -1611,6 +1613,8 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                podPriorityClassName:
+                  type: string
                 port:
                   format: int32
                   type: integer

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -70,6 +70,7 @@ spec:
 | fluentd                 | [FluentdSpec](#Fluentd-Spec)   | {}      | Fluentd configurations                                                  |
 | watchNamespaces         | []string       | ""      | Limit namespaces from where to read Flow and Output specs               |
 | controlNamespace        | string         | ""      | Control namespace that contains ClusterOutput and ClusterFlow resources |
+| podPriorityClassName    | string         | ""      | Name of a priority class to launch fluentbit with                       |
 
 #### Fluentd Spec
 
@@ -91,6 +92,7 @@ You can customize the `fluentd` statefulset with the following parameters.
 | nodeSelector | [NodeSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#nodeselector-v1-core) | {} | A node selector represents the union of the results of one or more label queries over a set of nodes |
 | metrics | [Metrics](./logging-operator-monitoring.md#metrics-variables) | {} | Metrics defines the service monitor endpoints |
 | security | [Security](./security#security-variables) | {} | Security defines Fluentd, Fluentbit deployment security properties |
+| podPriorityClassName | string | "" | Name of a priority class to launch fluentd with |
 
 
 **`logging` with custom fluentd pvc** 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/goph/emperror v0.17.2
 	github.com/onsi/gomega v1.5.0
 	github.com/pborman/uuid v1.2.0
-	github.com/prometheus/common v0.6.0
 	github.com/spf13/cast v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	k8s.io/api v0.0.0-20190813020757-36bff7324fb7

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/Azure/azure-pipeline-go v0.1.8/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9a
 github.com/Azure/azure-sdk-for-go v23.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.0.0-20181022225951-5152f14ace1c/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/Azure/go-autorest v11.2.8+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -448,6 +449,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -467,6 +469,7 @@ go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0 h1:sFPn2GLc3poCkfrpIXGhBD2X0CMIo4Q/zSULXrj/+uc=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
+go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -496,6 +499,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -605,6 +609,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190813034749-528a2984e271 h1:T33mP0l8Vpvq5ocfcmgKXW2GhpymOUxqiAh4FgBsJck=
 golang.org/x/tools v0.0.0-20190813034749-528a2984e271/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
@@ -665,6 +670,7 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b h1:aBGgKJUM9Hk/3AE8WaZIApnTxG35kbuQba2w+SXqezo=
 k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -65,6 +65,7 @@ func (r *Reconciler) daemonSet() (runtime.Object, k8sutil.DesiredState, error) {
 					ServiceAccountName: r.getServiceAccount(),
 					Volumes:            r.generateVolume(),
 					Tolerations:        r.Logging.Spec.FluentbitSpec.Tolerations,
+					PriorityClassName:  r.Logging.Spec.FluentbitSpec.PodPriorityClassName,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup:      r.Logging.Spec.FluentbitSpec.Security.PodSecurityContext.FSGroup,
 						RunAsNonRoot: r.Logging.Spec.FluentbitSpec.Security.PodSecurityContext.RunAsNonRoot,

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -77,8 +77,9 @@ func (r *Reconciler) statefulsetSpec() *appsv1.StatefulSetSpec {
 					*r.fluentContainer(),
 					*newConfigMapReloader(r.Logging.Spec.FluentdSpec.ConfigReloaderImage),
 				},
-				NodeSelector: r.Logging.Spec.FluentdSpec.NodeSelector,
-				Tolerations:  r.Logging.Spec.FluentdSpec.Tolerations,
+				NodeSelector:      r.Logging.Spec.FluentdSpec.NodeSelector,
+				Tolerations:       r.Logging.Spec.FluentdSpec.Tolerations,
+				PriorityClassName: r.Logging.Spec.FluentdSpec.PodPriorityClassName,
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: r.Logging.Spec.FluentdSpec.Security.PodSecurityContext.RunAsNonRoot,
 					FSGroup:      r.Logging.Spec.FluentdSpec.Security.PodSecurityContext.FSGroup,

--- a/pkg/sdk/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/api/v1beta1/fluentbit_types.go
@@ -24,25 +24,26 @@ import (
 
 // FluentbitSpec defines the desired state of Fluentbit
 type FluentbitSpec struct {
-	Annotations         map[string]string           `json:"annotations,omitempty"`
-	Labels              map[string]string           `json:"labels,omitempty"`
-	Image               ImageSpec                   `json:"image,omitempty"`
-	TLS                 FluentbitTLS                `json:"tls,omitempty"`
-	TargetHost          string                      `json:"targetHost,omitempty"`
-	TargetPort          int32                       `json:"targetPort,omitempty"`
-	Resources           corev1.ResourceRequirements `json:"resources,omitempty"`
-	Parser              string                      `json:"parser,omitempty"` // deprecated, use InputTail.Parser instead
-	Tolerations         []corev1.Toleration         `json:"tolerations,omitempty"`
-	Metrics             *Metrics                    `json:"metrics,omitempty"`
-	Security            *Security                   `json:"security,omitempty"`
-	PositionDBLegacy    *KubernetesStorage          `json:"position_db,omitempty"` // deprecated, use PositionDB instead
-	PositionDB          KubernetesStorage           `json:"positiondb,omitempty"`
-	MountPath           string                      `json:"mountPath,omitempty"`
-	InputTail           InputTail                   `json:"inputTail,omitempty"`
-	FilterKubernetes    FilterKubernetes            `json:"filterKubernetes,omitempty"`
-	BufferStorage       BufferStorage               `json:"bufferStorage,omitempty"`
-	BufferStorageVolume KubernetesStorage           `json:"bufferStorageVolume,omitempty"`
-	CustomConfigSecret  string                      `json:"customConfigSecret,omitempty"`
+	Annotations          map[string]string           `json:"annotations,omitempty"`
+	Labels               map[string]string           `json:"labels,omitempty"`
+	Image                ImageSpec                   `json:"image,omitempty"`
+	TLS                  FluentbitTLS                `json:"tls,omitempty"`
+	TargetHost           string                      `json:"targetHost,omitempty"`
+	TargetPort           int32                       `json:"targetPort,omitempty"`
+	Resources            corev1.ResourceRequirements `json:"resources,omitempty"`
+	Parser               string                      `json:"parser,omitempty"` // deprecated, use InputTail.Parser instead
+	Tolerations          []corev1.Toleration         `json:"tolerations,omitempty"`
+	Metrics              *Metrics                    `json:"metrics,omitempty"`
+	Security             *Security                   `json:"security,omitempty"`
+	PositionDBLegacy     *KubernetesStorage          `json:"position_db,omitempty"` // deprecated, use PositionDB instead
+	PositionDB           KubernetesStorage           `json:"positiondb,omitempty"`
+	MountPath            string                      `json:"mountPath,omitempty"`
+	InputTail            InputTail                   `json:"inputTail,omitempty"`
+	FilterKubernetes     FilterKubernetes            `json:"filterKubernetes,omitempty"`
+	BufferStorage        BufferStorage               `json:"bufferStorage,omitempty"`
+	BufferStorageVolume  KubernetesStorage           `json:"bufferStorageVolume,omitempty"`
+	CustomConfigSecret   string                      `json:"customConfigSecret,omitempty"`
+	PodPriorityClassName string                      `json:"podPriorityClassName,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/sdk/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/api/v1beta1/fluentd_types.go
@@ -42,7 +42,8 @@ type FluentdSpec struct {
 	Security            *Security                   `json:"security,omitempty"`
 	Scaling             *FluentdScaling             `json:"scaling,omitempty"`
 	// +kubebuilder:validation:enum=fatal,error,warn,info,debug,trace
-	LogLevel string `json:"logLevel,omitempty"`
+	LogLevel             string `json:"logLevel,omitempty"`
+	PodPriorityClassName string `json:"podPriorityClassName,omitempty"`
 }
 
 // +kubebuilder:object:generate=true


### PR DESCRIPTION
Logging is critical infrastructure, and so users may wish to ensure that
fluentd and/or fluentbit are scheduled before other workloads on nodes. This
is done through exposing `PriorityClassName` in the `fluentd` and `fluentbit`
CRDs.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This adds support for setting priority classes for fluentd and fluentbit.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Operators may wish to ensure that they get scheduled to nodes before other workloads, and to ensure that they get priority in terms of resources


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed) (updated helm docs, no changes needed to charts)
