### PR TITLE
make fluentdPvcSpec a pointer to make it easier to use with old clients

### DIFF
--- a/charts/logging-operator/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/templates/logging.banzaicloud.io_loggings.yaml
@@ -1250,8 +1250,8 @@ spec:
                     type: string
                   type: object
                 bufferStorageVolume:
-                  description: BufferStorageVolume is the alternative volume to use
-                    if PVC is disabled
+                  description: BufferStorageVolume is by default configured as PVC
+                    using FluentdPvcSpec
                   properties:
                     emptyDir:
                       description: Represents an empty directory for a pod. Empty

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -1250,8 +1250,8 @@ spec:
                     type: string
                   type: object
                 bufferStorageVolume:
-                  description: BufferStorageVolume is the alternative volume to use
-                    if PVC is disabled
+                  description: BufferStorageVolume is by default configured as PVC
+                    using FluentdPvcSpec
                   properties:
                     emptyDir:
                       description: Represents an empty directory for a pod. Empty

--- a/pkg/sdk/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/api/v1beta1/fluentd_types.go
@@ -27,9 +27,9 @@ type FluentdSpec struct {
 	TLS         FluentdTLS        `json:"tls,omitempty"`
 	Image       ImageSpec         `json:"image,omitempty"`
 	// Deprecated, use BufferStorageVolume to configure PVC explicitly
-	FluentdPvcSpec corev1.PersistentVolumeClaimSpec `json:"fluentdPvcSpec,omitempty"`
-	DisablePvc     bool                             `json:"disablePvc,omitempty"`
-	// BufferStorageVolume is the alternative volume to use if PVC is disabled
+	FluentdPvcSpec *corev1.PersistentVolumeClaimSpec `json:"fluentdPvcSpec,omitempty"`
+	DisablePvc     bool                              `json:"disablePvc,omitempty"`
+	// BufferStorageVolume is by default configured as PVC using FluentdPvcSpec
 	BufferStorageVolume KubernetesStorage           `json:"bufferStorageVolume,omitempty"`
 	VolumeMountChmod    bool                        `json:"volumeMountChmod,omitempty"`
 	VolumeModImage      ImageSpec                   `json:"volumeModImage,omitempty"`

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -128,6 +128,9 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 				copy.Spec.FluentdSpec.Annotations["prometheus.io/port"] = string(copy.Spec.FluentdSpec.Metrics.Port)
 			}
 		}
+		if copy.Spec.FluentdSpec.FluentdPvcSpec == nil {
+			copy.Spec.FluentdSpec.FluentdPvcSpec = &v1.PersistentVolumeClaimSpec{}
+		}
 		if copy.Spec.FluentdSpec.FluentdPvcSpec.AccessModes == nil {
 			copy.Spec.FluentdSpec.FluentdPvcSpec.AccessModes = []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
@@ -146,7 +149,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 		// DisablePvc will stay for a while. The alternative would be to set a hostPath or emptyDir explicitly
 		if copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim == nil {
 			copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim = &PersistentVolumeClaim{
-				PersistentVolumeClaimSpec: copy.Spec.FluentdSpec.FluentdPvcSpec,
+				PersistentVolumeClaimSpec: *copy.Spec.FluentdSpec.FluentdPvcSpec.DeepCopy(),
 			}
 		}
 		if copy.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName == "" {

--- a/pkg/sdk/api/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/sdk/api/v1beta1/zz_generated.deepcopy.go
@@ -465,7 +465,11 @@ func (in *FluentdSpec) DeepCopyInto(out *FluentdSpec) {
 	}
 	out.TLS = in.TLS
 	out.Image = in.Image
-	in.FluentdPvcSpec.DeepCopyInto(&out.FluentdPvcSpec)
+	if in.FluentdPvcSpec != nil {
+		in, out := &in.FluentdPvcSpec, &out.FluentdPvcSpec
+		*out = new(v1.PersistentVolumeClaimSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	in.BufferStorageVolume.DeepCopyInto(&out.BufferStorageVolume)
 	out.VolumeModImage = in.VolumeModImage
 	out.ConfigReloaderImage = in.ConfigReloaderImage


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
We use the sdk from banzaicloud/pipeline where we have a 1.13 k8s client that makes it hard to create a Logging CR with default values, since the PersistentVolumeClaimSpec has a field that is pointer but not tagged as omitempty and will fail validations on the newer server versions.

This PR makes it easier to do by making the whole fluentdPvcSpec field omitable.
