### PR TITLE
V1: Permit custom deployment strategy for fluentd

### DIFF
--- a/charts/logging-operator-fluent/README.md
+++ b/charts/logging-operator-fluent/README.md
@@ -49,5 +49,6 @@ This chart applies Fluentd and Fluent-bit custom resources to [Logging Operator]
 | `fluentd.fluentdPvcSpec.resources.requests.storage` | Fluentd persistence volume size                        | `21Gi`                         |
 | `fluentd.resources`                                 | Fluentd container resource requests and limits         | `{}`                           |
 | `fluentd.tolerations`                               | Fluentd tolerations                                    | `nil`                          |
+| `fluentd.deploymentStrategy`                        | Fluentd deployment strategy                            | `Rolling Update`               |
 | `fluentd.tlsSecret`                                 | Secret name that contains Fluentd TLS client cert      | Ignored if `tls.secretName` is specified. Must refer to a secret of type `kubernetes.io/tls`. |
 | `psp.enabled`                                       | Install PodSecurityPolicy                              | `false`                        |

--- a/charts/logging-operator-fluent/templates/fluentd-cr.yaml
+++ b/charts/logging-operator-fluent/templates/fluentd-cr.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if .Values.fluentd.tolerations }}
   tolerations: {{ toYaml .Values.fluentd.tolerations | nindent 4 }}
   {{- end }}
+  {{- if .Values.fluentd.deploymentStrategy }}
+  deploymentStrategy: {{ .Values.fluentd.deploymentStrategy }}
+  {{- end }}
   tls:
     enabled: {{ .Values.tls.enabled }}
 {{- if $fluentdUseGenericSecret }}

--- a/charts/logging-operator-fluent/values.yaml
+++ b/charts/logging-operator-fluent/values.yaml
@@ -40,6 +40,7 @@ fluentd:
     repository: "jimmidyson/configmap-reload"
     pullPolicy: "IfNotPresent"
   tolerations:
+  deploymentStrategy:
   fluentdPvcSpec:
     accessModes:
       - ReadWriteOnce

--- a/pkg/apis/logging/v1alpha1/fluentd_types.go
+++ b/pkg/apis/logging/v1alpha1/fluentd_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"strconv"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,6 +43,7 @@ type FluentdSpec struct {
 	Resources           corev1.ResourceRequirements      `json:"resources,omitempty"`
 	ServiceType         corev1.ServiceType               `json:"serviceType,omitempty"`
 	Tolerations         []corev1.Toleration              `json:"tolerations,omitempty"`
+	DeploymentStrategy  appsv1.DeploymentStrategyType    `json:"deploymentStrategy,omitempty"`
 }
 
 // FluentdTLS defines the TLS configs

--- a/pkg/resources/fluentd/deployment.go
+++ b/pkg/resources/fluentd/deployment.go
@@ -32,7 +32,7 @@ func (r *Reconciler) deployment() runtime.Object {
 		deploymentName = r.Fluentd.Labels["release"] + "-fluentd"
 	}
 
-	return &appsv1.Deployment{
+	deployment := appsv1.Deployment{
 		ObjectMeta: templates.FluentdObjectMeta(deploymentName, util.MergeLabels(r.Fluentd.Labels, labelSelector), r.Fluentd),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: util.IntPointer(1),
@@ -88,6 +88,12 @@ func (r *Reconciler) deployment() runtime.Object {
 			},
 		},
 	}
+	if r.Fluentd.Spec.DeploymentStrategy != "" || r.Fluentd.Spec.DeploymentStrategy != appsv1.RollingUpdateDeploymentStrategyType {
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: r.Fluentd.Spec.DeploymentStrategy,
+		}
+	}
+	return &deployment
 }
 
 func newConfigMapReloader(spec loggingv1alpha1.ImageSpec) *corev1.Container {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Added a field `deploymentStrategy` to the fluentd CRD, and add support to the helm chart. The field controls the value of `Spec.Strategy` in the fluentd deployment generated by the operator, which defaults to `RollingUpdate`. The current default behaviour is preserved if the new chart value is left unset, i.e. the CRD spec remains the same. If the value is set, e.g. to `Restart`, then the CRD will be updated accordingly and the fluentd deployment's spec will get `Spec.Strategy` equal to `Restart`.


### Why?
In some providers and storage classes attempting to rollout changes to the fluentd deployment will result in the rollout hanging due to a multi-attach volume error. The solution to this is to terminate the old fluentd pod before starting the new one.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
