### PR TITLE
Fixes for ServiceOperator-less prometheus monitoring

### DIFF
--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -49,7 +49,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, k8sutil.DesiredState, err
 }
 
 func (r *Reconciler) monitorServiceMetrics() (runtime.Object, k8sutil.DesiredState, error) {
-	if r.Logging.Spec.FluentbitSpec.Metrics != nil {
+	if r.Logging.Spec.FluentbitSpec.Metrics != nil && r.Logging.Spec.FluentbitSpec.Metrics.ServiceMonitor {
 		return &v1.ServiceMonitor{
 			ObjectMeta: r.FluentbitObjectMeta(fluentbitServiceName + "-metrics"),
 			Spec: v1.ServiceMonitorSpec{

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -77,7 +77,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, k8sutil.DesiredState, err
 }
 
 func (r *Reconciler) monitorServiceMetrics() (runtime.Object, k8sutil.DesiredState, error) {
-	if r.Logging.Spec.FluentdSpec.Metrics != nil {
+	if r.Logging.Spec.FluentdSpec.Metrics != nil && r.Logging.Spec.FluentdSpec.Metrics.ServiceMonitor {
 		return &v1.ServiceMonitor{
 			ObjectMeta: r.FluentdObjectMeta(ServiceName + "-metrics"),
 			Spec: v1.ServiceMonitorSpec{

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -125,7 +125,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 				copy.Spec.FluentdSpec.Annotations["prometheus.io/scrape"] = "true"
 
 				copy.Spec.FluentdSpec.Annotations["prometheus.io/path"] = copy.Spec.FluentdSpec.Metrics.Path
-				copy.Spec.FluentdSpec.Annotations["prometheus.io/port"] = string(copy.Spec.FluentdSpec.Metrics.Port)
+				copy.Spec.FluentdSpec.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", copy.Spec.FluentdSpec.Metrics.Port)
 			}
 		}
 		if copy.Spec.FluentdSpec.FluentdPvcSpec == nil {
@@ -274,7 +274,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 			if copy.Spec.FluentbitSpec.Metrics.PrometheusAnnotations {
 				copy.Spec.FluentbitSpec.Annotations["prometheus.io/scrape"] = "true"
 				copy.Spec.FluentbitSpec.Annotations["prometheus.io/path"] = copy.Spec.FluentbitSpec.Metrics.Path
-				copy.Spec.FluentbitSpec.Annotations["prometheus.io/port"] = string(copy.Spec.FluentbitSpec.Metrics.Port)
+				copy.Spec.FluentbitSpec.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", copy.Spec.FluentbitSpec.Metrics.Port)
 			}
 		}
 		if copy.Spec.FluentbitSpec.MountPath == "" {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no|yes
| API breaks?     | kinda
| Deprecations?   | no|yes
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
There are two commits here:
- Only deploy the `ServiceMonitor` when explicitly asked
- Correctly specify the port in the annotations when `PrometheusAnnotations` is set to `true`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Monitoring with Prometheus without using the Prometheus Operator is broken without these changes

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested on EKS 1.14

There is a potential issue where people relied on the behavior of the `ServiceMonitor` objects being created just by the presence of the `metrics` object in the CRD. However, I decided to leave the current behavior to match what the documentation says. We can switch this, and make it default to `true` if a `metrics` object exists if y'all want to preserve this behavior.