### PR TITLE
change the fluentd internal log destination to null

### DIFF
--- a/docs/crds.md
+++ b/docs/crds.md
@@ -105,7 +105,7 @@ You can customize the `fluentd` statefulset with the following parameters.
 | metrics | [Metrics](./logging-operator-monitoring.md#metrics-variables) | {} | Metrics defines the service monitor endpoints |
 | security | [Security](./security#security-variables) | {} | Security defines Fluentd, Fluentbit deployment security properties |
 | podPriorityClassName | string | "" | Name of a priority class to launch fluentd with |
-| fluentLogDestination | string | "stdout" | Send internal fluentd logs to stdout, or use "null" to omit them |
+| fluentLogDestination | string | "null" | Send internal fluentd logs to stdout, or use "null" to omit them |
 
 
 **`logging` with custom pvc volume for buffers** 

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -194,7 +194,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 			}
 		}
 		if copy.Spec.FluentdSpec.FluentLogDestination == "" {
-			copy.Spec.FluentdSpec.FluentLogDestination = "stdout"
+			copy.Spec.FluentdSpec.FluentLogDestination = "null"
 		}
 	}
 	if copy.Spec.FluentbitSpec != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Change the default destination for fluentd internal logs to be the null output.


### Why?
Because these logs are sent to stdout anyways, so there is no use in sending them to stdout again.
