### PR TITLE
Allow annotations in logging-operator helm chart

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the logging-operator c
 | `resources`                                         | CPU/Memory resource requests/limits                    | `{}`                           |
 | `tolerations`                                       | Node Tolerations                                       | `[]`                           |
 | `nodeSelector`                                      | Define which Nodes the Pods are scheduled on.          | `{}`                           |
+| `annotations`                                       | Define annotations for logging-operator pods           | `{}`                           |
 | `podSecurityContext`                                | Pod SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/)                                                                                             | `{"runAsNonRoot": true, "runAsUser": 1000, "fsGroup": 2000}` |
 | `securityContext`                                   | Container SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/)                                                                                             | `{"allowPrivilegeEscalation": false, "readOnlyRootFilesystem": true}` |
 

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "logging-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{-  end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    |yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds annotations for the logging-operator itself in the helm chart


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We specifically use this to add annotations for prometheus scraping

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested on EKS 1.14.

It is possible for our specific use-case could be solved by adding a prometheus-specific toggle, but allowing generic annotations seems to be a better solution.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
