### PR TITLE
create and allow the /buffers path for fluent

### DIFF
--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                                          | `IfNotPresent`                                             |
 | `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                                   | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                                          | true                                                       |
-| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.7.4-alpine-10`                                          |
+| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.7.4-alpine-11`                                          |
 | `fluentd.image.repository`                          | Fluentd container image repository                                       | `banzaicloud/fluentd`                                      |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                                            | `IfNotPresent`                                             |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag                               | `latest`                                                   |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -107,7 +107,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                           |
-| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.7.4-alpine-10`              |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.7.4-alpine-11`              |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `banzaicloud/fluentd`          |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -221,7 +221,7 @@ spec:
   fluentd: 
     image:
       repository: banzaicloud/fluentd
-      tag: v1.7.4-alpine-10
+      tag: v1.7.4-alpine-11
       pullPolicy: IfNotPresent
   fluentbit: {}
   controlNamespace: logging

--- a/fluentd-image/v1.7/Dockerfile
+++ b/fluentd-image/v1.7/Dockerfile
@@ -59,7 +59,8 @@ RUN addgroup -S fluent && adduser -S -G fluent fluent \
     && mkdir -p /fluentd/log \
     # configuration/plugins path (default: copied from .)
     && mkdir -p /fluentd/etc /fluentd/plugins \
-    && chown -R fluent /fluentd && chgrp -R fluent /fluentd
+    && chown -R fluent /fluentd && chgrp -R fluent /fluentd \
+    && mkdir -p /buffers && chown -R fluent /buffers
 
 
 COPY fluent.conf /fluentd/etc/

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -85,7 +85,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 			copy.Spec.FluentdSpec.Image.Repository = "banzaicloud/fluentd"
 		}
 		if copy.Spec.FluentdSpec.Image.Tag == "" {
-			copy.Spec.FluentdSpec.Image.Tag = "v1.7.4-alpine-10"
+			copy.Spec.FluentdSpec.Image.Tag = "v1.7.4-alpine-11"
 		}
 		if copy.Spec.FluentdSpec.Image.PullPolicy == "" {
 			copy.Spec.FluentdSpec.Image.PullPolicy = "IfNotPresent"


### PR DESCRIPTION
Without allowing access to the /buffers path the configcheck fails for file output configured to write there as it has no pvc mounted.