### PR TITLE
Docfix

### DIFF
--- a/charts/logging-demo/templates/flow.yaml
+++ b/charts/logging-demo/templates/flow.yaml
@@ -11,8 +11,8 @@ spec:
     - parser:
         remove_key_name_field: true
         reserve_data: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
   selectors:
     app.kubernetes.io/name: log-generator
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -375,10 +375,10 @@ metadata:
   namespace: default
 spec:
   filters:
-    - parse:
+    - parser:
         remove_key_name_field: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
     - tag_normaliser:
         format: ${namespace_name}.${pod_name}.${container_name}
   outputRefs:

--- a/docs/example-es-nginx.md
+++ b/docs/example-es-nginx.md
@@ -122,8 +122,8 @@ spec:
     - parser:
         remove_key_name_field: true
         reserve_data: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
   selectors:
     app: nginx
   outputRefs:

--- a/docs/example-kafka-nginx.md
+++ b/docs/example-kafka-nginx.md
@@ -106,8 +106,8 @@ spec:
     - parser:
         remove_key_name_field: true
         reserve_data: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
   selectors:
     app: nginx
   outputRefs:

--- a/docs/examples/logging_flow_geoip.yaml
+++ b/docs/examples/logging_flow_geoip.yaml
@@ -8,8 +8,8 @@ spec:
         format: ${namespace_name}.${pod_name}.${container_name}
     - parser:
         remove_key_name_field: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
     - geoip:
         records:
           - city: ${city.names.en["remote"]}

--- a/docs/examples/logging_flow_with_dedot.yaml
+++ b/docs/examples/logging_flow_with_dedot.yaml
@@ -7,8 +7,8 @@ spec:
   filters:
     - parser:
         remove_key_name_field: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
     - tag_normaliser:
         format: ${namespace_name}.${pod_name}.${container_name}
     - dedot: {}

--- a/docs/examples/logging_flow_with_filters.yaml
+++ b/docs/examples/logging_flow_with_filters.yaml
@@ -7,8 +7,8 @@ spec:
   filters:
     - parser:
         remove_key_name_field: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
     - tag_normaliser:
         format: ${namespace_name}.${pod_name}.${container_name}
   outputRefs:

--- a/docs/examples/logging_flow_with_multi_format.yaml
+++ b/docs/examples/logging_flow_with_multi_format.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   filters:
   - parser:
-      parsers:
-      - type: multi_format
+      parse:
+        type: multi_format
         patterns:
         - format: nginx
         - format: regexp

--- a/docs/logging-operator-monitoring.md
+++ b/docs/logging-operator-monitoring.md
@@ -218,8 +218,8 @@ spec:
     - parser:
         remove_key_name_field: true
         reserve_data: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
   selectors:
     app.kubernetes.io/instance: nginx-demo
     app.kubernetes.io/name: nginx-logging-demo

--- a/docs/plugins/filters/geoip.md
+++ b/docs/plugins/filters/geoip.md
@@ -11,8 +11,8 @@
         format: ${namespace_name}.${pod_name}.${container_name}
     - parser:
         remove_key_name_field: true
-        parsers:
-          - type: nginx
+        parse:
+          type: nginx
     - geoip:
         geoip_lookup_keys: remote_addr
         records:

--- a/pkg/sdk/model/filter/geoip.go
+++ b/pkg/sdk/model/filter/geoip.go
@@ -31,8 +31,8 @@ import (
 //        format: ${namespace_name}.${pod_name}.${container_name}
 //    - parser:
 //        remove_key_name_field: true
-//        parsers:
-//          - type: nginx
+//        parse:
+//          type: nginx
 //    - geoip:
 //        geoip_lookup_keys: remote_addr
 //        records:

--- a/pkg/sdk/model/filter/parser_test.go
+++ b/pkg/sdk/model/filter/parser_test.go
@@ -26,8 +26,8 @@ func TestParser(t *testing.T) {
 	CONFIG := []byte(`
 remove_key_name_field: true
 reserve_data: true
-parsers:
-- type: nginx
+parse:
+  type: nginx
 `)
 	expected := `
 <filter **>
@@ -51,8 +51,8 @@ func TestParserMultiParser(t *testing.T) {
 	CONFIG := []byte(`
 remove_key_name_field: true
 reserve_data: true
-parsers:
-- type: multi_format
+parse:
+  type: multi_format
   patterns:
   - format: nginx
   - format: regexp


### PR DESCRIPTION
Fix documentation to avoid the deprecated version of the `parser` filter config (and fix a typo in crds.yaml)