### PR TITLE
Update docs to use Elastic Cloud on Kubernetes

### DIFF
--- a/charts/logging-demo/templates/output_elasticsearch.yaml
+++ b/charts/logging-demo/templates/output_elasticsearch.yaml
@@ -8,11 +8,17 @@ metadata:
 {{ include "logging-demo.labels" . | indent 4 }}
 spec:
   elasticsearch:
-    host: elasticsearch-elasticsearch-cluster.{{ .Release.Namespace }}.svc.cluster.local
+    host: quickstart-es-http.{{ .Release.Namespace }}
     port: 9200
     scheme: https
     ssl_verify: false
     ssl_version: TLSv1_2
+    user: elastic
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: quickstart-es-elastic-user
+          key: elastic
     buffer:
       timekey: 1m
       timekey_wait: 30s


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
Replaces the upmc operator with ECK in the demo docs.


### Why?
The upmc operator uses an outdated version of elasticsearch and seems to have been unmaintained for several months now. 

