### PR TITLE
raise memory limit to avoid OOM errors when chunks are getting full

### DIFF
--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -176,7 +176,7 @@ func (l *Logging) SetDefaults() (*Logging, error) {
 		}
 		if copy.Spec.FluentdSpec.Resources.Limits == nil {
 			copy.Spec.FluentdSpec.Resources.Limits = v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("200M"),
+				v1.ResourceMemory: resource.MustParse("400M"),
 				v1.ResourceCPU:    resource.MustParse("1000m"),
 			}
 		}


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Raise the default memory limit

### Why?
Because when chunks gets full (256M) then the default 200M memory limit will be exhausted.
