### PR TITLE
circleci: bump helm orb version to 0.0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  helm: banzaicloud/helm@0.0.5
+  helm: banzaicloud/helm@0.0.6
   docker: circleci/docker@0.5.13
 
 


### PR DESCRIPTION
helm version upgraded to `2.16.1` in `banzaicloud/helm@0.0.6`