### PR TITLE
Update deployment image to use version 2.7.0

### DIFF
--- a/docs/deploy/manifests/deployment.yaml
+++ b/docs/deploy/manifests/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: logging-operator
-          image: "banzaicloud/logging-operator:2.1.0"
+          image: "banzaicloud/logging-operator:2.7.0"
           imagePullPolicy: IfNotPresent
           resources:
             {}


### PR DESCRIPTION
### What's in this PR?
After much tinkering and trying to figure out why the operater wouldn't work i realized the operater image in the deployment hasn't been updated in quite some time.