### PR TITLE
[charts/logging-operator] fix service label

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "2.7.1"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 2.7.1
+version: 2.7.2

--- a/charts/logging-operator/templates/service.yaml
+++ b/charts/logging-operator/templates/service.yaml
@@ -15,4 +15,3 @@ spec:
   selector:
     app.kubernetes.io/name:  {{ include "logging-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: query


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #306
| License         | Apache 2.0

This PR fixes the following issue https://github.com/banzaicloud/logging-operator/issues/306

An erroneous label selector was set on the logging-operator service.