### PR TITLE
Add explicit default for timekey_wait buffer parameter

### DIFF
--- a/docs/plugins/outputs/buffer.md
+++ b/docs/plugins/outputs/buffer.md
@@ -30,6 +30,6 @@
 | retry_randomize | bool | No | - | If true, output plugin will retry after randomized interval not to do burst retries<br> |
 | disable_chunk_backup | bool | No | - | Instead of storing unrecoverable chunks in the backup directory, just discard them. This option is new in Fluentd v1.2.6.<br> |
 | timekey | string | Yes | 10m | Output plugin will flush chunks per specified time (enabled when time is specified in chunk keys)<br> |
-| timekey_wait | string | No | - | Output plugin writes chunks after timekey_wait seconds later after timekey expiration<br> |
+| timekey_wait | string | No | 10m | Output plugin writes chunks after timekey_wait seconds later after timekey expiration<br> |
 | timekey_use_utc | bool | No | - | Output plugin decides to use UTC or not to format placeholders using timekey<br> |
 | timekey_zone | string | No | - | The timezone (-0700 or Asia/Tokyo) string for formatting timekey placeholders<br> |

--- a/pkg/sdk/model/output/buffer.go
+++ b/pkg/sdk/model/output/buffer.go
@@ -98,7 +98,7 @@ type Buffer struct {
 	// +kubebuilder:validation:Optional
 	Timekey string `json:"timekey" plugin:"default:10m"`
 	// Output plugin writes chunks after timekey_wait seconds later after timekey expiration
-	TimekeyWait string `json:"timekey_wait,omitempty"`
+	TimekeyWait string `json:"timekey_wait,omitempty" plugin:"default:10m"`
 	// Output plugin decides to use UTC or not to format placeholders using timekey
 	TimekeyUseUtc bool `json:"timekey_use_utc,omitempty"`
 	// The timezone (-0700 or Asia/Tokyo) string for formatting timekey placeholders


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Add an explicit default for the `timekey_wait` buffer parameter.


### Why?
It is highly confusing that logging-operator specifies "no default" for the `timekey_wait` parameter. This causes fluentd itself to default to `10m` which can be confusingly long both for testing logging-operator and for production environments. While not altering fluentd's defaults, this commit at least makes it explicit and obvious for new users.

- [x] User guide and development docs updated (if needed)