### PR TITLE
Add component label to fluentd pods and service selector

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -39,7 +39,7 @@ func (r *Reconciler) appconfigMap() (runtime.Object, reconciler.DesiredState, er
 	data := make(map[string][]byte)
 	data[AppConfigKey] = []byte(*r.config)
 	return &corev1.Secret{
-		ObjectMeta: r.FluentdObjectMeta(AppSecretConfigName),
+		ObjectMeta: r.FluentdObjectMeta(AppSecretConfigName, ComponentFluentd),
 		Data:       data,
 	}, reconciler.StatePresent, nil
 }
@@ -151,7 +151,7 @@ func (r *Reconciler) configCheckCleanup(currentHash string) ([]string, error) {
 
 func (r *Reconciler) newCheckSecret(hashKey string) *v1.Secret {
 	return &v1.Secret{
-		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey)),
+		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey), ComponentFluentd),
 		Data: map[string][]byte{
 			ConfigKey: []byte(*r.config),
 		},
@@ -164,7 +164,7 @@ func (r *Reconciler) newCheckOutputSecret(hashKey string) (*v1.Secret, error) {
 		return nil, err
 	}
 	if secret, ok := obj.(*v1.Secret); ok {
-		secret.ObjectMeta = r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-output-%s", hashKey))
+		secret.ObjectMeta = r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-output-%s", hashKey), ComponentFluentd)
 		return secret, nil
 	}
 	return nil, errors.New("output secret is invalid, unable to create output secret for config check")
@@ -172,7 +172,7 @@ func (r *Reconciler) newCheckOutputSecret(hashKey string) (*v1.Secret, error) {
 
 func (r *Reconciler) newCheckPod(hashKey string) *v1.Pod {
 	pod := &v1.Pod{
-		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey)),
+		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey), ComponentConfigCheck),
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Volumes: []v1.Volume{

--- a/pkg/resources/fluentd/component.go
+++ b/pkg/resources/fluentd/component.go
@@ -1,0 +1,20 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentd
+
+const (
+	ComponentFluentd     = "fluentd"
+	ComponentConfigCheck = "fluentd-configcheck"
+)

--- a/pkg/resources/fluentd/components.go
+++ b/pkg/resources/fluentd/components.go
@@ -1,6 +1,0 @@
-package fluentd
-
-const (
-	ComponentFluentd     = "fluentd"
-	ComponentConfigCheck = "fluentd-configcheck"
-)

--- a/pkg/resources/fluentd/components.go
+++ b/pkg/resources/fluentd/components.go
@@ -1,0 +1,6 @@
+package fluentd
+
+const (
+	ComponentFluentd     = "fluentd"
+	ComponentConfigCheck = "fluentd-configcheck"
+)

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -73,7 +73,7 @@ func (r *Reconciler) secretConfig() (runtime.Object, reconciler.DesiredState, er
 	}
 
 	configs := &corev1.Secret{
-		ObjectMeta: r.FluentdObjectMeta(SecretConfigName),
+		ObjectMeta: r.FluentdObjectMeta(SecretConfigName, ComponentFluentd),
 		Data: map[string][]byte{
 			"fluent.conf":  []byte(fluentdDefaultTemplate),
 			"input.conf":   []byte(inputConfig),

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -63,9 +63,15 @@ type Desire struct {
 	BeforeUpdateHook func(runtime.Object) (reconciler.DesiredState, error)
 }
 
-func (r *Reconciler) getFluentdLabels() map[string]string {
-	return util.MergeLabels(r.Logging.Spec.FluentdSpec.Labels, map[string]string{
-		"app.kubernetes.io/name": "fluentd"}, generateLoggingRefLabels(r.Logging.ObjectMeta.GetName()))
+func (r *Reconciler) getFluentdLabels(component string) map[string]string {
+	return util.MergeLabels(
+		r.Logging.Spec.FluentdSpec.Labels,
+		map[string]string{
+			"app.kubernetes.io/name":      "fluentd",
+			"app.kubernetes.io/component": component,
+		},
+		generateLoggingRefLabels(r.Logging.ObjectMeta.GetName()),
+	)
 }
 
 func (r *Reconciler) getServiceAccount() string {

--- a/pkg/resources/fluentd/meta.go
+++ b/pkg/resources/fluentd/meta.go
@@ -20,11 +20,11 @@ import (
 )
 
 // FluentdObjectMeta creates an objectMeta for resource fluentd
-func (r *Reconciler) FluentdObjectMeta(name string) metav1.ObjectMeta {
+func (r *Reconciler) FluentdObjectMeta(name, component string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
 		Name:      r.Logging.QualifiedName(name),
 		Namespace: r.Logging.Spec.ControlNamespace,
-		Labels:    r.getFluentdLabels(),
+		Labels:    r.getFluentdLabels(component),
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: r.Logging.APIVersion,
@@ -39,10 +39,10 @@ func (r *Reconciler) FluentdObjectMeta(name string) metav1.ObjectMeta {
 }
 
 // FluentdObjectMetaClusterScope creates an objectMeta for resource fluentd
-func (r *Reconciler) FluentdObjectMetaClusterScope(name string) metav1.ObjectMeta {
+func (r *Reconciler) FluentdObjectMetaClusterScope(name, component string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
 		Name:   r.Logging.QualifiedName(name),
-		Labels: r.getFluentdLabels(),
+		Labels: r.getFluentdLabels(component),
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: r.Logging.APIVersion,

--- a/pkg/resources/fluentd/psp.go
+++ b/pkg/resources/fluentd/psp.go
@@ -26,7 +26,7 @@ import (
 func (r *Reconciler) clusterPodSecurityPolicy() (runtime.Object, reconciler.DesiredState, error) {
 	if r.Logging.Spec.FluentdSpec.Security.PodSecurityPolicyCreate {
 		return &policyv1beta1.PodSecurityPolicy{
-			ObjectMeta: r.FluentdObjectMetaClusterScope(r.Logging.QualifiedName(PodSecurityPolicyName)),
+			ObjectMeta: r.FluentdObjectMetaClusterScope(r.Logging.QualifiedName(PodSecurityPolicyName), ComponentFluentd),
 			Spec: policyv1beta1.PodSecurityPolicySpec{
 				Volumes: []policyv1beta1.FSType{
 					"configMap",
@@ -53,7 +53,7 @@ func (r *Reconciler) clusterPodSecurityPolicy() (runtime.Object, reconciler.Desi
 		}, reconciler.StatePresent, nil
 	}
 	return &policyv1beta1.PodSecurityPolicy{
-		ObjectMeta: r.FluentdObjectMeta(PodSecurityPolicyName),
+		ObjectMeta: r.FluentdObjectMeta(PodSecurityPolicyName, ComponentFluentd),
 		Spec:       policyv1beta1.PodSecurityPolicySpec{},
 	}, reconciler.StateAbsent, nil
 }
@@ -61,7 +61,7 @@ func (r *Reconciler) clusterPodSecurityPolicy() (runtime.Object, reconciler.Desi
 func (r *Reconciler) pspRole() (runtime.Object, reconciler.DesiredState, error) {
 	if *r.Logging.Spec.FluentdSpec.Security.RoleBasedAccessControlCreate && r.Logging.Spec.FluentdSpec.Security.PodSecurityPolicyCreate {
 		return &rbacv1.Role{
-			ObjectMeta: r.FluentdObjectMeta(roleName + "-psp"),
+			ObjectMeta: r.FluentdObjectMeta(roleName+"-psp", ComponentFluentd),
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups:     []string{"policy"},
@@ -73,14 +73,14 @@ func (r *Reconciler) pspRole() (runtime.Object, reconciler.DesiredState, error) 
 		}, reconciler.StatePresent, nil
 	}
 	return &rbacv1.Role{
-		ObjectMeta: r.FluentdObjectMeta(roleName + "-psp"),
+		ObjectMeta: r.FluentdObjectMeta(roleName+"-psp", ComponentFluentd),
 		Rules:      []rbacv1.PolicyRule{}}, reconciler.StateAbsent, nil
 }
 
 func (r *Reconciler) pspRoleBinding() (runtime.Object, reconciler.DesiredState, error) {
 	if *r.Logging.Spec.FluentdSpec.Security.RoleBasedAccessControlCreate && r.Logging.Spec.FluentdSpec.Security.PodSecurityPolicyCreate {
 		return &rbacv1.RoleBinding{
-			ObjectMeta: r.FluentdObjectMeta(roleBindingName + "-psp"),
+			ObjectMeta: r.FluentdObjectMeta(roleBindingName+"-psp", ComponentFluentd),
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "Role",
 				APIGroup: "rbac.authorization.k8s.io",
@@ -96,6 +96,6 @@ func (r *Reconciler) pspRoleBinding() (runtime.Object, reconciler.DesiredState, 
 		}, reconciler.StatePresent, nil
 	}
 	return &rbacv1.RoleBinding{
-		ObjectMeta: r.FluentdObjectMeta(roleBindingName + "-psp"),
+		ObjectMeta: r.FluentdObjectMeta(roleBindingName+"-psp", ComponentFluentd),
 		RoleRef:    rbacv1.RoleRef{}}, reconciler.StateAbsent, nil
 }

--- a/pkg/resources/fluentd/rbac.go
+++ b/pkg/resources/fluentd/rbac.go
@@ -24,7 +24,7 @@ import (
 func (r *Reconciler) role() (runtime.Object, reconciler.DesiredState, error) {
 	if *r.Logging.Spec.FluentdSpec.Security.RoleBasedAccessControlCreate {
 		return &rbacv1.Role{
-			ObjectMeta: r.FluentdObjectMeta(roleName),
+			ObjectMeta: r.FluentdObjectMeta(roleName, ComponentFluentd),
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
@@ -35,14 +35,14 @@ func (r *Reconciler) role() (runtime.Object, reconciler.DesiredState, error) {
 		}, reconciler.StatePresent, nil
 	}
 	return &rbacv1.Role{
-		ObjectMeta: r.FluentdObjectMeta(roleName),
+		ObjectMeta: r.FluentdObjectMeta(roleName, ComponentFluentd),
 		Rules:      []rbacv1.PolicyRule{}}, reconciler.StateAbsent, nil
 }
 
 func (r *Reconciler) roleBinding() (runtime.Object, reconciler.DesiredState, error) {
 	if *r.Logging.Spec.FluentdSpec.Security.RoleBasedAccessControlCreate {
 		return &rbacv1.RoleBinding{
-			ObjectMeta: r.FluentdObjectMeta(roleBindingName),
+			ObjectMeta: r.FluentdObjectMeta(roleBindingName, ComponentFluentd),
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "Role",
 				APIGroup: "rbac.authorization.k8s.io",
@@ -58,17 +58,17 @@ func (r *Reconciler) roleBinding() (runtime.Object, reconciler.DesiredState, err
 		}, reconciler.StatePresent, nil
 	}
 	return &rbacv1.RoleBinding{
-		ObjectMeta: r.FluentdObjectMeta(roleBindingName),
+		ObjectMeta: r.FluentdObjectMeta(roleBindingName, ComponentFluentd),
 		RoleRef:    rbacv1.RoleRef{}}, reconciler.StateAbsent, nil
 }
 
 func (r *Reconciler) serviceAccount() (runtime.Object, reconciler.DesiredState, error) {
 	if *r.Logging.Spec.FluentdSpec.Security.RoleBasedAccessControlCreate && r.Logging.Spec.FluentdSpec.Security.ServiceAccount == "" {
 		return &corev1.ServiceAccount{
-			ObjectMeta: r.FluentdObjectMeta(defaultServiceAccountName),
+			ObjectMeta: r.FluentdObjectMeta(defaultServiceAccountName, ComponentFluentd),
 		}, reconciler.StatePresent, nil
 	}
 	return &corev1.ServiceAccount{
-		ObjectMeta: r.FluentdObjectMeta(defaultServiceAccountName),
+		ObjectMeta: r.FluentdObjectMeta(defaultServiceAccountName, ComponentFluentd),
 	}, reconciler.StateAbsent, nil
 }

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -26,7 +26,7 @@ import (
 
 func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) {
 	desired := &corev1.Service{
-		ObjectMeta: r.FluentdObjectMeta(ServiceName),
+		ObjectMeta: r.FluentdObjectMeta(ServiceName, ComponentFluentd),
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
@@ -35,7 +35,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 					TargetPort: intstr.IntOrString{IntVal: 24240},
 				},
 			},
-			Selector: r.getFluentdLabels(),
+			Selector: r.getFluentdLabels(ComponentFluentd),
 			Type:     corev1.ServiceTypeClusterIP,
 		},
 	}
@@ -55,7 +55,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, error) {
 	if r.Logging.Spec.FluentdSpec.Metrics != nil {
 		return &corev1.Service{
-			ObjectMeta: r.FluentdObjectMeta(ServiceName + "-metrics"),
+			ObjectMeta: r.FluentdObjectMeta(ServiceName+"-metrics", ComponentFluentd),
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
 					{
@@ -65,21 +65,21 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 						TargetPort: intstr.IntOrString{IntVal: r.Logging.Spec.FluentdSpec.Metrics.Port},
 					},
 				},
-				Selector:  r.getFluentdLabels(),
+				Selector:  r.getFluentdLabels(ComponentFluentd),
 				Type:      corev1.ServiceTypeClusterIP,
 				ClusterIP: "None",
 			},
 		}, reconciler.StatePresent, nil
 	}
 	return &corev1.Service{
-		ObjectMeta: r.FluentdObjectMeta(ServiceName + "-monitor"),
+		ObjectMeta: r.FluentdObjectMeta(ServiceName+"-monitor", ComponentFluentd),
 		Spec:       corev1.ServiceSpec{}}, reconciler.StateAbsent, nil
 }
 
 func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.DesiredState, error) {
 	if r.Logging.Spec.FluentdSpec.Metrics != nil && r.Logging.Spec.FluentdSpec.Metrics.ServiceMonitor {
 		return &v1.ServiceMonitor{
-			ObjectMeta: r.FluentdObjectMeta(ServiceName + "-metrics"),
+			ObjectMeta: r.FluentdObjectMeta(ServiceName+"-metrics", ComponentFluentd),
 			Spec: v1.ServiceMonitorSpec{
 				JobLabel:        "",
 				TargetLabels:    nil,
@@ -90,14 +90,14 @@ func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.Desired
 					Interval:      r.Logging.Spec.FluentdSpec.Metrics.Interval,
 					ScrapeTimeout: r.Logging.Spec.FluentdSpec.Metrics.Timeout,
 				}},
-				Selector:          v12.LabelSelector{MatchLabels: r.getFluentdLabels()},
+				Selector:          v12.LabelSelector{MatchLabels: r.getFluentdLabels(ComponentFluentd)},
 				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{r.Logging.Spec.ControlNamespace}},
 				SampleLimit:       0,
 			},
 		}, reconciler.StatePresent, nil
 	}
 	return &v1.ServiceMonitor{
-		ObjectMeta: r.FluentdObjectMeta(ServiceName + "-metrics"),
+		ObjectMeta: r.FluentdObjectMeta(ServiceName+"-metrics", ComponentFluentd),
 		Spec:       v1.ServiceMonitorSpec{},
 	}, reconciler.StateAbsent, nil
 }

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -32,7 +32,7 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 	if !r.Logging.Spec.FluentdSpec.DisablePvc {
 		spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 			{
-				ObjectMeta: r.FluentdObjectMeta(r.Logging.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName),
+				ObjectMeta: r.FluentdObjectMeta(r.Logging.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName, ComponentFluentd),
 				Spec:       r.Logging.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeClaimSpec,
 				Status: corev1.PersistentVolumeClaimStatus{
 					Phase: corev1.ClaimPending,
@@ -40,8 +40,9 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 			},
 		}
 	}
+
 	desired := &appsv1.StatefulSet{
-		ObjectMeta: r.FluentdObjectMeta(StatefulSetName),
+		ObjectMeta: r.FluentdObjectMeta(StatefulSetName, ComponentFluentd),
 		Spec:       spec,
 	}
 
@@ -69,7 +70,7 @@ func (r *Reconciler) statefulsetSpec() *appsv1.StatefulSetSpec {
 	return &appsv1.StatefulSetSpec{
 		Replicas: util.IntPointer(cast.ToInt32(r.Logging.Spec.FluentdSpec.Scaling.Replicas)),
 		Selector: &metav1.LabelSelector{
-			MatchLabels: r.getFluentdLabels(),
+			MatchLabels: r.getFluentdLabels(ComponentFluentd),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: r.generatePodMeta(),
@@ -134,7 +135,7 @@ func (r *Reconciler) fluentContainer() *corev1.Container {
 
 func (r *Reconciler) generatePodMeta() metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{
-		Labels: r.getFluentdLabels(),
+		Labels: r.getFluentdLabels(ComponentFluentd),
 	}
 	if r.Logging.Spec.FluentdSpec.Annotations != nil {
 		meta.Annotations = r.Logging.Spec.FluentdSpec.Annotations


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?

This pull request adds a `component` label to fluentd pods and service selector.

Without the label, the service considers the pod used to check config as a valid target (as the labels of the pod match the service selector).

With the `component` label, only the pods from the fluentd statefullset match the fluentd service.
