### PR TITLE
Fix: link to troubleshooting guideline in docs

### DIFF
--- a/docs/quickstarts/es-nginx.md
+++ b/docs/quickstarts/es-nginx.md
@@ -197,4 +197,6 @@ To validate that the deployment was successful, complete the following steps.
 1. Open the Kibana dashboard in your browser: [https://localhost:5601](https://localhost:5601). You should see the dashboard and some sample log messages from the demo application.
 
 <p align="center"><img src="../img/es_kibana.png" width="660"></p>
-> If you don't get the expected result you can find help in the [troubleshooting-guideline](../troubleshooting.md).
+
+> If you don't get the expected result you can find help in the [troubleshooting-guideline](../troubleshooting.md)
+


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| License         | Apache 2.0


### What's in this PR?
Troubleshooting guideline link is not rendering properly. This edit fixes link and blockquote.


### Why?
Issues with  documentation