### PR TITLE
Add ClusterFlows/Outputs to logging chart

### DIFF
--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "2.7.0"
 description: A Helm chart to configure logging resource for the Logging operator
 name: logging-operator-logging
-version: 2.7.3
+version: 2.7.4
 icon: https://raw.githubusercontent.com/banzaicloud/logging-operator/master/docs/img/icon.png

--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -42,3 +42,5 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentd.tolerations`                               | Tolerations for fluentd statefulset                                      | none                                                       |
 | `fluentd.nodeSelector`                              | Node selector for fluentd pods                                           | none                                                       |
 | `fluentd.podPriorityClassName`                      | Priority class name for fluentd pods                                     | none                                                       |
+| `clusterFlows`                                      | Array of ClusterFlows to be created                                      | []                                                         |
+| `clusterOutputs`                                    | Array of ClusterOutputs to be created                                    | []                                                         |

--- a/charts/logging-operator-logging/templates/clusterflows.yaml
+++ b/charts/logging-operator-logging/templates/clusterflows.yaml
@@ -1,0 +1,12 @@
+{{- range $clusterflow := .Values.clusterFlows }}
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterFlow
+metadata:
+  name: {{ $clusterflow.name }}
+  namespace: {{ .Values.controlNamespace | default .Release.Namespace }}
+  labels:
+{{ include "logging-operator-logging.labels" . | indent 4 }}
+spec:
+{{ $clusterflow.spec | indent 2 }}
+{{- end -}}

--- a/charts/logging-operator-logging/templates/clusteroutputs.yaml
+++ b/charts/logging-operator-logging/templates/clusteroutputs.yaml
@@ -1,0 +1,12 @@
+{{- range $clusteroutput := .Values.clusterOutputs }}
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterOutput
+metadata:
+  name: {{ $clusteroutput.name }}
+  namespace: {{ .Values.controlNamespace | default .Release.Namespace }}
+  labels:
+{{ include "logging-operator-logging.labels" . | indent 4 }}
+spec:
+{{ $clusteroutput.spec | indent 2 }}
+{{- end -}}

--- a/charts/logging-operator-logging/values.yaml
+++ b/charts/logging-operator-logging/values.yaml
@@ -51,3 +51,22 @@ tls:
 watchNamespaces: []
 # Control namespace that contains ClusterOutput and ClusterFlow resources
 controlNamespace: ""
+
+# ClusterFlows to deploy
+clusterFlows: []
+
+# ClusterOutputs to deploy
+clusterOutputs: []
+
+# Send all pod logs to kafka
+# clusterFlows:
+#   - name: all-pods
+#     spec:
+#       outputRefs:
+#         - kafka
+# clusterOutputs:
+#   - name: kafka
+#     spec:
+#       kafka:
+#         brokers: kafka-headless.kafka.svc.cluster.local:29092
+#         default_topic: topic


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?

Adds the option of deploying ClusterFlow and ClusterOutput objects as part of the logging chart.

### Why?

Currently to deploy the operator and all our config requires deploying:

1. The operator chart
2. The logging chart to create the logging object
3. A custom chart which contains our cluster-wide configuration

These PR will allow us to drop the custom chart.
