### PR TITLE
added helm chart namespace override

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.0.0-rc.2"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 3.0.1
+version: 3.0.2

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the logging-operator c
 | `image.pullPolicy`                                  | Container pull policy                                  | `IfNotPresent`                 |
 | `nameOverride`                                      | Override name of app                                   | ``                             |
 | `fullnameOverride`                                  | Override full name of app                              | ``                             |
+| `namespaceOverride`                                 | Override namespace of app                              | ``                             |
 | `watchNamespace`                                    | Namespace to watch for LoggingOperator CRD             | ``                             |
 | `rbac.enabled`                                      | Create rbac service account and roles                  | `true`                         |
 | `rbac.psp.enabled`                                  | Must be used with `rbac.enabled` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled.              | `false`                        |

--- a/charts/logging-operator/templates/_helpers.tpl
+++ b/charts/logging-operator/templates/_helpers.tpl
@@ -25,6 +25,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Provides the namespace the chart will be installed in using the builtin .Release.Namespace,
+or, if provided, and manually overwritten namespace value.
+*/}}
+{{- define "logging-operator.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{ .Values.namespaceOverride -}}
+{{- else -}}
+{{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "logging-operator.chart" -}}

--- a/charts/logging-operator/templates/_helpers.tpl
+++ b/charts/logging-operator/templates/_helpers.tpl
@@ -26,7 +26,7 @@ If release name contains chart name it will be used as a full name.
 
 {{/*
 Provides the namespace the chart will be installed in using the builtin .Release.Namespace,
-or, if provided, and manually overwritten namespace value.
+or, if provided, a manually overwritten namespace value.
 */}}
 {{- define "logging-operator.namespace" -}}
 {{- if .Values.namespaceOverride -}}

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "logging-operator.fullname" . }}
+  namespace: {{ include "logging-operator.namespace" . }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
 spec:

--- a/charts/logging-operator/templates/psp.yaml
+++ b/charts/logging-operator/templates/psp.yaml
@@ -4,6 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   creationTimestamp: null
   name: psp.logging-operator
+  namespace: {{ include "logging-operator.namespace" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'

--- a/charts/logging-operator/templates/rbac.yaml
+++ b/charts/logging-operator/templates/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "logging-operator.fullname" . }}
+  namespace: {{ include "logging-operator.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "logging-operator.name" . }}
     helm.sh/chart: {{ include "logging-operator.chart" . }}
@@ -129,7 +130,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "logging-operator.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "logging-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/logging-operator/templates/service.yaml
+++ b/charts/logging-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "logging-operator.fullname" . }}
+  namespace: {{ include "logging-operator.namespace" . }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
 spec:

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -12,6 +12,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 annotations: {}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   |yes
| License         | Apache 2.0


### What's in this PR?
This PR adds the ability to manually override the deployment namespace for helm chart installations.
Provide a way to manually override the deployment namespace. This is mainly used by ci-cd tools which dont have the ability to change namespace context.


### Why?
Some legacy cd tools lack the ability to change namespace context, this feature allows them to manually override the namespace without having that ability.

### Checklist
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)