### PR TITLE
Remove use of QualifiedName in clusterPodSecurityPolicy() as it is al…

### DIFF
--- a/pkg/resources/fluentd/psp.go
+++ b/pkg/resources/fluentd/psp.go
@@ -26,7 +26,7 @@ import (
 func (r *Reconciler) clusterPodSecurityPolicy() (runtime.Object, reconciler.DesiredState, error) {
 	if r.Logging.Spec.FluentdSpec.Security.PodSecurityPolicyCreate {
 		return &policyv1beta1.PodSecurityPolicy{
-			ObjectMeta: r.FluentdObjectMetaClusterScope(r.Logging.QualifiedName(PodSecurityPolicyName), ComponentFluentd),
+			ObjectMeta: r.FluentdObjectMetaClusterScope(PodSecurityPolicyName, ComponentFluentd),
 			Spec: policyv1beta1.PodSecurityPolicySpec{
 				Volumes: []policyv1beta1.FSType{
 					"configMap",


### PR DESCRIPTION
…so done in FluentdObjectMetaClusterScope() causing the name of the psp to be incorrect

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #389
| License         | Apache 2.0

### What's in this PR?
Adjustment to the clusterPodSecurityPolicy function to remove duplicate string in fluentd PSP name fixing #389 