### PR TITLE
Fix chart example as spec needs to be string

### DIFF
--- a/charts/logging-operator-logging/values.yaml
+++ b/charts/logging-operator-logging/values.yaml
@@ -53,12 +53,12 @@ clusterOutputs: []
 # Send all pod logs to kafka
 # clusterFlows:
 #   - name: all-pods
-#     spec:
+#     spec: |
 #       outputRefs:
 #         - kafka
 # clusterOutputs:
 #   - name: kafka
-#     spec:
+#     spec: |
 #       kafka:
 #         brokers: kafka-headless.kafka.svc.cluster.local:29092
 #         default_topic: topic


### PR DESCRIPTION
Update the example of a clusterflow/output as the value must be a string and not a map.