### PR TITLE
circleci: trigger docs update on release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,16 @@ jobs:
           image: <<parameters.image>>
           tag: latest
 
+  trigger-docs-update:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Trigger
+          command: scripts/trigger-docs-update.sh "${CIRCLE_TAG}"
+
 workflows:
   version: 2
   build:
@@ -238,6 +248,12 @@ workflows:
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:dev|rc)\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - trigger-docs-update:
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
 

--- a/scripts/trigger-docs-update.sh
+++ b/scripts/trigger-docs-update.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euf
+
+PROJECT_SLUG='gh/banzaicloud/logging-operator-docs'
+RELEASE_TAG="$1"
+
+function main()
+{
+    curl \
+        -u "${CIRCLE_TOKEN}:" \
+        -X POST \
+        --header "Content-Type: application/json" \
+        -d "{
+            \"branch\": \"master\",
+            \"parameters\": {
+                \"remote-trigger\": true,
+                \"generated-docs-update\": true,
+                \"release-tag\": \"${RELEASE_TAG}\"
+            }
+        }" "https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline"
+}
+
+main "$@"


### PR DESCRIPTION
Triggers docs update workflow on `logging-operator-docs` when release tag pushed.