### PR TITLE
feat: use fluentd gracefulReload for configuration updates

### DIFF
--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -161,7 +161,7 @@ func newConfigMapReloader(spec v1beta1.ImageSpec) *corev1.Container {
 		Args: []string{
 			"-volume-dir=/fluentd/etc",
 			"-volume-dir=/fluentd/app-config/",
-			"-webhook-url=http://127.0.0.1:24444/api/config.reload",
+			"-webhook-url=http://127.0.0.1:24444/api/config.gracefulReload",
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Switch the `config-reloader` to use the `fluentd` [/api/config.gracefulReload](https://docs.fluentd.org/deployment/rpc#api-config-gracefulreload) webhook.

`/api/config.gracefulReload` sends a `SIGUSR2` signal to the fluentd process, instead of `SIGHUP`. This is a more graceful method of reloading the configuration that doesn't require restarting the worker process.

As of v1.9.0, the [fluentd documentation](https://docs.fluentd.org/deployment/signals#sigusr2) recommends using the `SIGUSR2` signal for this purpose.

### Why?
Sending the `SIGHUP` signal to fluentd and restarting the worker process can become problematic in an environment with regular configuration updates (eg. continuous deployments).

The repeated worker restarts results in the fluentd service becoming _regularly_ inaccessible:
```
[2020/04/22 08:02:17] [error] [io] TCP connection failed: default-logging-fluentd.logging.svc:24240 (Connection refused)
[2020/04/22 08:02:17] [error] [out_fw] no upstream connections available
[2020/04/22 08:02:17] [error] [io] TCP connection failed: default-logging-fluentd.logging.svc:24240 (Connection refused)
[2020/04/22 08:02:17] [error] [out_fw] no upstream connections available
```