### PR TITLE
Add Flunetd annotations to config checker #462

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -249,6 +249,9 @@ func (r *Reconciler) newCheckPod(hashKey string) *v1.Pod {
 			},
 		},
 	}
+	if r.Logging.Spec.FluentdSpec.Annotations != nil {
+		pod.Annotations = r.Logging.Spec.FluentdSpec.Annotations
+	}
 	if r.Logging.Spec.FluentdSpec.TLS.Enabled {
 		tlsVolume := corev1.Volume{
 			Name: "fluentd-tls",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #462
| License         | Apache 2.0


### What's in this PR?
Any FluentD annotations that are declared get applied to the fluentd-configcheck pod.  
Chose to put snippet inline with the creation of the Pod as it seems the least disruptive.  I did attempt to add code into the `meta.go`  but that introduced unwanted side-effects such as restarting Fluentd when a config changed. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [x ] Related Helm chart(s) updated (if needed)


