### PR TITLE
Only add HostPath to PSP if PositionDB enabled

### DIFF
--- a/pkg/resources/fluentbit/psp.go
+++ b/pkg/resources/fluentbit/psp.go
@@ -43,13 +43,15 @@ func (r *Reconciler) clusterPodSecurityPolicy() (runtime.Object, reconciler.Desi
 			})
 		}
 
-		r.Logging.Spec.FluentbitSpec.PositionDB.WithDefaultHostPath(
-			fmt.Sprintf(v1beta1.HostPath, r.Logging.Name, TailPositionVolume))
+		if r.Logging.Spec.FluentbitSpec.PositionDB.HostPath != nil {
+			r.Logging.Spec.FluentbitSpec.PositionDB.WithDefaultHostPath(
+				fmt.Sprintf(v1beta1.HostPath, r.Logging.Name, TailPositionVolume))
 
-		allowedHostPaths = append(allowedHostPaths, policyv1beta1.AllowedHostPath{
-			PathPrefix: r.Logging.Spec.FluentbitSpec.PositionDB.HostPath.Path,
-			ReadOnly:   false,
-		})
+			allowedHostPaths = append(allowedHostPaths, policyv1beta1.AllowedHostPath{
+				PathPrefix: r.Logging.Spec.FluentbitSpec.PositionDB.HostPath.Path,
+				ReadOnly:   false,
+			})
+		}
 
 		return &policyv1beta1.PodSecurityPolicy{
 			ObjectMeta: r.FluentbitObjectMetaClusterScope(fluentbitPodSecurityPolicyName),


### PR DESCRIPTION
Fix nil exception
```
rvgl  4:00 PM
if enabled fluentbit.security.podSecurityPolicyCreate: true. I got error in logging-operator:
E0520 13:57:43.466474       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 482 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1560d80, 0x2489790)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1560d80, 0x2489790)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/banzaicloud/logging-operator/pkg/resources/fluentbit.(*Reconciler).clusterPodSecurityPolicy(0xc0014280a0, 0x1936a80, 0xc002bf3340, 0x192b580, 0x190e960, 0x0, 0x0)
	/workspace/pkg/resources/fluentbit/psp.go:50 +0x2ca
github.com/banzaicloud/logging-operator/pkg/resources/fluentbit.(*Reconciler).Reconcile(0xc0014280a0, 0x0, 0x0, 0x0)
	/workspace/pkg/resources/fluentbit/fluentbit.go:91 +0x30a
github.com/banzaicloud/logging-operator/controllers.(*LoggingReconciler).Reconcile(0xc000705ac0, 0x0, 0x0, 0xc000568bc0, 0x18, 0xc000efbcd8, 0xc000729e60, 0xc0006be008, 0x1939ca0)
	/workspace/controllers/logging_controller.go:114 +0x49f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0007266c0, 0x15b4d00, 0xc0001fe040, 0xc00045e500)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007266c0, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0007266c0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0016d83f0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0016d83f0, 0x3b9aca00, 0x0, 0x1, 0xc000342de0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0016d83f0, 0x3b9aca00, 0xc000342de0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:193 +0x328
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```