### PR TITLE
Omit empty clusterIP in the logging service spec to avoid helm3 upgrade failures

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.2.0"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 3.2.0
+version: 3.2.1

--- a/charts/logging-operator/templates/service.yaml
+++ b/charts/logging-operator/templates/service.yaml
@@ -7,7 +7,9 @@ metadata:
 {{ include "logging-operator.labels" . | indent 4 }}
 spec:
   type: ClusterIP
+  {{- with  .Values.http.service.clusterIP }}
   clusterIP: {{ .Values.http.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.http.port }}
       targetPort: http


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Do not add the clusterIP with an empty value as it makes helm3 upgrades to fail.

