### PR TITLE
Fix helm chart to properly set clusterIP

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.2.0"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 3.2.1
+version: 3.2.2

--- a/charts/logging-operator/templates/service.yaml
+++ b/charts/logging-operator/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   {{- with  .Values.http.service.clusterIP }}
-  clusterIP: {{ .Values.http.service.clusterIP }}
+  clusterIP: {{ . }}
   {{- end }}
   ports:
     - port: {{ .Values.http.port }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -44,7 +44,7 @@ http:
   # Service definition for query http service
   service:
     type: ClusterIP
-    clusterIP: ""
+    clusterIP: None
     # Annotations to query http service
     annotations: {}
     # Labels to query http service


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix http.service.clusterIP value to mind the scoping and to be backwards compatible with 3.0.5 and earlier chart versions

### Why?
Charts prior to 3.0.5 (inclusive) used `ClusterIP: None` which was then changed to `ClusterIP: ""` which is bad for two reasons:
- it is backwards incompatible
- it behaves really bad with helm3, which tries to update this value on each upgrade to set it back to the empty string which fails on the API server
