### PR TITLE
Removed not exists resources from crd kustomize template

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,12 +2,10 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/logging.banzaicloud.io_fluentbits.yaml
 - bases/logging.banzaicloud.io_flows.yaml
 - bases/logging.banzaicloud.io_clusterflows.yaml
 - bases/logging.banzaicloud.io_outputs.yaml
 - bases/logging.banzaicloud.io_clusteroutputs.yaml
-- bases/logging.banzaicloud.io_fluentds.yaml
 - bases/logging.banzaicloud.io_loggings.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 


### PR DESCRIPTION
Hello. I see two resources, specified in `config/crd/kustomization.yaml` file, but they do not exists by specified path. As well I tried execute `kustomize build` in `config/default`, and it failed also. Can we fix it like that?