### PR TITLE
fix: logging-operator-logging logging.yaml template

### DIFF
--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "3.4.0"
 description: A Helm chart to configure logging resource for the Logging operator
 name: logging-operator-logging
-version: 3.4.0
+version: 3.4.1
 icon: https://raw.githubusercontent.com/banzaicloud/logging-operator/master/docs/img/icon.png

--- a/charts/logging-operator-logging/templates/logging.yaml
+++ b/charts/logging-operator-logging/templates/logging.yaml
@@ -28,8 +28,10 @@ spec:
       enabled: true
       secretName: {{ .Values.tls.fluentdSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentd-tls" ) }}
       sharedKey: "{{ .Values.tls.sharedKey }}"
-    {{- else -}}
+    {{- else }}
       enabled: false
+      secretName: {{ .Values.tls.fluentdSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentd-tls" ) }}
+      sharedKey: "{{ .Values.tls.sharedKey }}"
     {{- end }}
     {{- if .Values.fluentd }}
 {{ toYaml .Values.fluentd | indent 4}}
@@ -40,8 +42,10 @@ spec:
       enabled: true
       secretName: {{ .Values.tls.fluentbitSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentbit-tls" ) }}
       sharedKey: "{{ .Values.tls.sharedKey }}"
-    {{- else -}}
+    {{- else }}
       enabled: false
+      secretName: {{ .Values.tls.fluentbitSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentbit-tls" ) }}
+      sharedKey: "{{ .Values.tls.sharedKey }}"
     {{- end }}
     {{- if .Values.fluentbit }}
 {{ toYaml .Values.fluentbit | indent 4}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #540
| License         | Apache 2.0


### What's in this PR?
Modifications to logging.yaml template to fix logging object when it renders without TLS enabled


### Why?
Running tls.enabled=false produces invalid yaml


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

