### PR TITLE
Updating ClusterRole for logging-operator

### DIFF
--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -95,13 +95,7 @@ rules:
   resources:
   - podsecuritypolicies
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - "*"
 - apiGroups:
   - logging.banzaicloud.io
   resources:

--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -95,7 +95,14 @@ rules:
   resources:
   - podsecuritypolicies
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - use
 - apiGroups:
   - logging.banzaicloud.io
   resources:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Slack-Link
| License         | Apache 2.0


### What's in this PR?
Fixes a bug, when installing the logging-operator-stack via helm-chart in a K8s-Cluster with PSP admission controller enabled (fluentd-pod is not starting)
Because of a missing permission, the logging-operator is not able to pass the use-permission for PodSecurityPolicies to the fluentd-pods. Giving the logging-operator-role the use-permission, fixes this issue. I put in the "*" because the verbs-list meets all verbs.
Slack-Link: https://community-banzaicloud.slack.com/archives/CGMPPBZBK/p1599121640017600 



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x ] User guide and development docs updated (if needed)
- [x ] Related Helm chart(s) updated (if needed)
