### PR TITLE
Fix logging-operator Helm chart option for monitoring.serviceMonitor.enable

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.6.0"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 3.6.0
+version: 3.6.1

--- a/charts/logging-operator/templates/serviceMonitor.yaml
+++ b/charts/logging-operator/templates/serviceMonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.monitoring.serviceMonitor.Enabled }}
+{{ if .Values.monitoring.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
| Q | A
| --------------- | ---
| Bug fix? | yes
| New feature? | no
| API breaks? | no
| Deprecations? | no
| License | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixing case of `monitoring.serviceMonitor.enable` in the ServiceMonitor manifest

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
All documentation says that enable is lowercase, while in the chart it is uppercase


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
