### PR TITLE
Remove extra, useless `-d` flag in liveness check

### DIFF
--- a/fluentd-image/v1.10/healthy.sh
+++ b/fluentd-image/v1.10/healthy.sh
@@ -16,7 +16,7 @@ if [ ! -e ${BUFFER_PATH} ];
 then
   exit 1;
 fi;
-touch -d date -d "@$(($(date +%s) - $LIVENESS_THRESHOLD_SECONDS))" /tmp/marker-liveness;
+touch -d "@$(($(date +%s) - $LIVENESS_THRESHOLD_SECONDS))" /tmp/marker-liveness;
 if [ -z "$(find ${BUFFER_PATH} -type d -newer /tmp/marker-liveness -print -quit)" ];
 then
   exit 1;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This removes a spurious `-d` flag in the `touch` command in fluentd's liveness check.

### Why?

When you pass multiple of the same flag to `busybox`, only the last one is used.

```bash
/ # touch /tmp/marker-liveness 
/ # ls -lh /tmp/marker-liveness 
-rw-r--r--    1 root     root           0 Oct 14 14:39 /tmp/marker-liveness
/ # touch -d any -d bullshit -d whatsoever -d @1602683841 /tmp/marker-liveness 
/ # ls -lh /tmp/marker-liveness 
-rw-r--r--    1 root     root           0 Oct 14 13:57 /tmp/marker-liveness
```

Removing it adds clarity and removes confusion.
