### PR TITLE
Remove useless `-d date` in fluentd healthcheck

### DIFF
--- a/fluentd-image/v1.11/healthy.sh
+++ b/fluentd-image/v1.11/healthy.sh
@@ -16,7 +16,7 @@ if [ ! -e ${BUFFER_PATH} ];
 then
   exit 1;
 fi;
-touch -d date -d "@$(($(date +%s) - $LIVENESS_THRESHOLD_SECONDS))" /tmp/marker-liveness;
+touch -d "@$(($(date +%s) - $LIVENESS_THRESHOLD_SECONDS))" /tmp/marker-liveness;
 if [ -z "$(find ${BUFFER_PATH} -type d -newer /tmp/marker-liveness -print -quit)" ];
 then
   exit 1;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    |no
| API breaks?     |no
| Deprecations?   |no
| License         | Apache 2.0


### What's in this PR?
Remove the useless `-d date` in the healthcheck, as was done in the v10 image.


### Why?
Due to an oversight, I unfortunately did not include this in #539. Sorry about that.