### PR TITLE
fluentd:v1.11.5-alpine-1

### DIFF
--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                                          | `IfNotPresent`                                             |
 | `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                                   | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                                          | true                                                       |
-| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.11.4-alpine-6`                                          |
+| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.11.5-alpine-1`                                          |
 | `fluentd.image.repository`                          | Fluentd container image repository                                       | `ghcr.io/banzaicloud/fluentd`                                      |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                                            | `IfNotPresent`                                             |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag                               | `latest`                                                   |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -115,7 +115,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                           |
-| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.11.4-alpine-6`              |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.11.5-alpine-1`              |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `ghcr.io/banzaicloud/fluentd`          |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |

--- a/fluentd-image/v1.11/Dockerfile
+++ b/fluentd-image/v1.11/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.12
-LABEL Description="Fluentd docker image" Vendor="Banzai Cloud" Version="1.11.4"
+FROM alpine:3.12.1
+LABEL Description="Fluentd docker image" Vendor="Banzai Cloud" Version="1.11.5"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -26,7 +26,7 @@ RUN apk update \
  && gem install json -v 2.3.1 \
  && gem install async-http -v 0.52.5 \
  && gem install ext_monitor -v 0.1.2 \
- && gem install fluentd -v 1.11.4 \
+ && gem install fluentd -v 1.11.5 \
  && gem install prometheus-client -v 0.9.0 \
  && gem install bigdecimal -v 1.4.4 \
  && gem install fluent-plugin-kubernetes_metadata_filter -v 2.5.2 \

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -99,7 +99,7 @@ const (
 	DefaultFluentbitImageRepository = "fluent/fluent-bit"
 	DefaultFluentbitImageTag        = "1.6.4"
 	DefaultFluentdImageRepository   = "ghcr.io/banzaicloud/fluentd"
-	DefaultFluentdImageTag          = "v1.11.4-alpine-6"
+	DefaultFluentdImageTag          = "v1.11.5-alpine-1"
 )
 
 // SetDefaults fills empty attributes

--- a/pkg/sdk/model/output/kinesis_firehose.go
+++ b/pkg/sdk/model/output/kinesis_firehose.go
@@ -38,8 +38,8 @@ type _hugoKinesisFirehose interface{}
 type _docKinesisFirehose interface{}
 
 // +name:"Amazon Kinesis Firehose"
-// +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.2.3"
-// +version:"3.2.3"
+// +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.3.0"
+// +version:"3.3.0"
 // +description:"Fluent plugin for Amazon Kinesis"
 // +status:"Testing"
 type _metaKinesisFirehose interface{}

--- a/pkg/sdk/model/output/kinesis_stream.go
+++ b/pkg/sdk/model/output/kinesis_stream.go
@@ -38,8 +38,8 @@ type _hugoKinesisStream interface{}
 type _docKinesisStream interface{}
 
 // +name:"Amazon Kinesis Stream"
-// +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.2.3"
-// +version:"3.2.3"
+// +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.3.0"
+// +version:"3.3.0"
 // +description:"Fluent plugin for Amazon Kinesis"
 // +status:"GA"
 type _metaKinesis interface{}

--- a/pkg/sdk/model/output/loki.go
+++ b/pkg/sdk/model/output/loki.go
@@ -43,7 +43,7 @@ type _docLoki interface{}
 
 // +name:"Grafana Loki"
 // +url:"https://github.com/grafana/loki/tree/master/fluentd/fluent-plugin-grafana-loki"
-// +version:"1.2.15"
+// +version:"1.2.16"
 // +description:"Transfer logs to Loki"
 // +status:"GA"
 type _metaLoki interface{}


### PR DESCRIPTION
FluentD 1.11.4 -> 1.11.5

Updated plugins:
- fluent-plugin-cloudwatch-logs '0.11.0' -> '0.11.1'
- fluent-plugin-grafana-loki '1.2.15' -> '1.2.16'
- fluent-plugin-kinesis '3.2.3' -> ‘3.3.0'
- fluent-plugin-webhdfs' '1.2.5' -> '1.3.1'

New Plugins:
- fluent-plugin-syslog_rfc5424 '0.9.0.rc.5' 
- fluent-plugin-kubernetes_sumologic '2.4.2'

alpine:3.12 -> '3.12.1'

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
