### PR TITLE
helm/logging-operator-logging: render valid logging object when tls.e…

### DIFF
--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "3.8.0"
+appVersion: "3.8.1"
 description: A Helm chart to configure logging resource for the Logging operator
 name: logging-operator-logging
-version: 3.8.0
+version: 3.8.1
 icon: https://raw.githubusercontent.com/banzaicloud/logging-operator/master/docs/img/icon.png

--- a/charts/logging-operator-logging/templates/logging.yaml
+++ b/charts/logging-operator-logging/templates/logging.yaml
@@ -20,8 +20,9 @@ spec:
   controlNamespace: {{ .Values.controlNamespace | default .Release.Namespace }}
   {{- if .Values.defaultFlow }}
   defaultFlow:
-{{ toYaml .Values.defaultFlow | indent 4}}
+{{ toYaml .Values.defaultFlow | indent 4 }}
   {{- end }}
+  {{- if or .Values.tls.enabled .Values.fluentd }}
   fluentd:
     {{- if .Values.tls.enabled }}
     tls:
@@ -30,8 +31,12 @@ spec:
       sharedKey: "{{ .Values.tls.sharedKey }}"
     {{- end }}
     {{- if .Values.fluentd }}
-{{ toYaml .Values.fluentd | indent 4}}
-    {{- end}}
+{{ toYaml .Values.fluentd | indent 4 }}
+    {{- end }}
+  {{- else }}
+  fluentd: {}
+  {{- end }}
+  {{- if or .Values.tls.enabled .Values.fluentbit }}
   fluentbit:
     {{- if .Values.tls.enabled }}
     tls:
@@ -40,6 +45,9 @@ spec:
       sharedKey: "{{ .Values.tls.sharedKey }}"
     {{- end }}
     {{- if .Values.fluentbit }}
-{{ toYaml .Values.fluentbit | indent 4}}
-    {{- end}}
+{{ toYaml .Values.fluentbit | indent 4 }}
+    {{- end }}
+  {{- else }}
+  fluentbit: {}
+  {{- end }}
 


### PR DESCRIPTION
An invalid logging object is rendered with passing only tls.enable=false:
```
❯ helm template --set tls.enabled=false .
---
# Source: logging-operator-logging/templates/logging.yaml
apiVersion: logging.banzaicloud.io/v1beta1
kind: Logging
metadata:
  name: logging-operator-logging
  labels:
    app.kubernetes.io/name: logging-operator-logging
    helm.sh/chart: logging-operator-logging-3.8.0
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "3.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  controlNamespace: logging
  fluentd:
  fluentbit:
```

After this patch the following is rendered with is a valid logging object:
```
❯ helm template --set tls.enabled=false .
---
# Source: logging-operator-logging/templates/logging.yaml
apiVersion: logging.banzaicloud.io/v1beta1
kind: Logging
metadata:
  name: logging-operator-logging
  labels:
    app.kubernetes.io/name: logging-operator-logging
    helm.sh/chart: logging-operator-logging-3.8.0
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "3.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  controlNamespace: logging
  fluentd: {}
  fluentbit: {}
```