### PR TITLE
Fix PSP on k8s 1.19

### DIFF
--- a/charts/logging-operator/templates/clusterrolebinding.yaml
+++ b/charts/logging-operator/templates/clusterrolebinding.yaml
@@ -5,10 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "logging-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "logging-operator.name" . }}
-    helm.sh/chart: {{ include "logging-operator.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "logging-operator.labels" . | indent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "logging-operator.fullname" . }}

--- a/charts/logging-operator/templates/psp.yaml
+++ b/charts/logging-operator/templates/psp.yaml
@@ -2,12 +2,13 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  creationTimestamp: null
   name: psp.logging-operator
   namespace: {{ include "logging-operator.namespace" . }}
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
 spec:
   readOnlyRootFilesystem: true
   privileged: false

--- a/charts/logging-operator/templates/serviceaccount.yaml
+++ b/charts/logging-operator/templates/serviceaccount.yaml
@@ -6,8 +6,5 @@ metadata:
   name: {{ template "logging-operator.fullname" . }}
   namespace: {{ include "logging-operator.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "logging-operator.name" . }}
-    helm.sh/chart: {{ include "logging-operator.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "logging-operator.labels" . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/95817

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| License         | Apache 2.0


### What's in this PR?
### Why?
The operator psp didn't work when we upgraded to 1.19.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
