### PR TITLE
Add ServiceMonitor configuration options

### DIFF
--- a/charts/logging-operator/templates/serviceMonitor.yaml
+++ b/charts/logging-operator/templates/serviceMonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "logging-operator.namespace" . }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
+{{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -13,6 +16,14 @@ spec:
   endpoints:
   - port: http
     path: /metrics
+    {{- with .Values.monitoring.serviceMonitor.metricsRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ include "logging-operator.namespace" . }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -77,3 +77,6 @@ monitoring:
   # Create a Prometheus Operator ServiceMonitor object
   serviceMonitor:
     enabled: false
+    additionalLabels: {}
+    metricRelabelings: []
+    relabelings: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes
| License         | Apache 2.0


### What's in this PR?
Adds configuration options to serviceMonitor configuration for operator pods

### Why?
Allows the additional of labels just to the serviceMonitor, so multi tenant prometheus environments can select just the serviceMonitors they're interested in.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
