### PR TITLE
Assume Helm 3 as the default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,13 @@
 version: 2.1
 
 orbs:
-  helm: banzaicloud/helm@0.0.7
+  helm: banzaicloud/helm@0.0.8
   docker: circleci/docker@0.5.13
 
+executors:
+  helm311:
+    docker:
+      - image: ghcr.io/banzaicloud/helm:0.0.7
 
 jobs:
   build:
@@ -258,12 +262,14 @@ workflows:
   helm-chart:
     jobs:
       - helm/lint-chart:
+          executor: helm311
           filters:
             tags:
               ignore: /.*/
 
       - helm/publish-chart:
           context: helm
+          executor: helm311
           filters:
             branches:
               ignore: /.*/

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -18,7 +18,7 @@ annotations: {}
 
 ## Deploy CRDs used by Logging Operator.
 ##
-createCustomResource: true
+createCustomResource: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -39,8 +39,7 @@ function helm_deploy_logging_operator()
         logging-operator \
         --set image.tag='local' \
         --set image.repository='controller' \
-        "${SCRIPT_PATH}/../charts/logging-operator" \
-        --skip-crds 
+        "${SCRIPT_PATH}/../charts/logging-operator"
 }
 
 function configure_logging()


### PR DESCRIPTION
Do not install CRDs from templates.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Switch to assuming helm 3 by default when installing the chart and do not install CRDs as templates, but rely on the crds folder to install them.

### Why?
Because otherwise helm3 will fail when trying to install crds from templates, since those have already been installed in the beginning from the crds folder.
