### PR TITLE
Fix configcheck secret to be identical to production config

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -35,15 +35,9 @@ type ConfigCheckResult struct {
 	Message string
 }
 
-func (r *Reconciler) configCheckConfigSecret() (runtime.Object, reconciler.DesiredState, error) {
-	data, err := r.generateConfigSecret()
-	if err != nil {
-		return nil, nil, err
-	}
-	// Overwrite default includes
-	data["fluent.conf"] = []byte(fluentdConfigCheckTemplate)
-	// Add generated configuration
-	data["generated.conf"] = []byte(*r.config)
+func (r *Reconciler) appConfigSecret() (runtime.Object, reconciler.DesiredState, error) {
+	data := make(map[string][]byte)
+	data[AppConfigKey] = []byte(*r.config)
 	return &corev1.Secret{
 		ObjectMeta: r.FluentdObjectMeta(AppSecretConfigName, ComponentFluentd),
 		Data:       data,
@@ -120,7 +114,10 @@ func (r *Reconciler) configCheck() (*ConfigCheckResult, error) {
 		return nil, errors.WrapIff(err, "failed to get configcheck pod %s:%s", pod.Namespace, pod.Name)
 	}
 
-	checkSecret := r.newCheckSecret(hashKey)
+	checkSecret, err := r.newCheckSecret(hashKey)
+	if err != nil {
+		return nil, err
+	}
 	checkOutputSecret, err := r.newCheckOutputSecret(hashKey)
 	if err != nil {
 		return nil, err
@@ -150,7 +147,13 @@ func (r *Reconciler) configCheckCleanup(currentHash string) ([]string, error) {
 		if configHash == currentHash {
 			continue
 		}
-		if err := r.Client.Delete(context.TODO(), r.newCheckSecret(configHash)); err != nil {
+		newSecret, err := r.newCheckSecret(configHash)
+		if err != nil {
+			multierr = errors.Combine(multierr,
+				errors.Wrapf(err, "failed to create config check secret %s", configHash))
+			continue
+		}
+		if err := r.Client.Delete(context.TODO(), newSecret); err != nil {
 			if !apierrors.IsNotFound(err) {
 				multierr = errors.Combine(multierr,
 					errors.Wrapf(err, "failed to remove config check secret %s", configHash))
@@ -182,13 +185,17 @@ func (r *Reconciler) configCheckCleanup(currentHash string) ([]string, error) {
 	return removedHashes, multierr
 }
 
-func (r *Reconciler) newCheckSecret(hashKey string) *v1.Secret {
+func (r *Reconciler) newCheckSecret(hashKey string) (*v1.Secret, error) {
+	data, err := r.generateConfigSecret()
+	if err != nil {
+		return nil, err
+	}
+	data["generated.conf"] = []byte(*r.config)
+	data["fluent.conf"] = []byte(fluentdConfigCheckTemplate)
 	return &v1.Secret{
 		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey), ComponentConfigCheck),
-		Data: map[string][]byte{
-			"generated.conf": []byte(*r.config),
-		},
-	}
+		Data:       data,
+	}, nil
 }
 
 func (r *Reconciler) newCheckOutputSecret(hashKey string) (*v1.Secret, error) {

--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -190,7 +190,7 @@ func (r *Reconciler) newCheckSecret(hashKey string) (*v1.Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	data["generated.conf"] = []byte(*r.config)
+	data[ConfigCheckKey] = []byte(*r.config)
 	data["fluent.conf"] = []byte(fluentdConfigCheckTemplate)
 	return &v1.Secret{
 		ObjectMeta: r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-%s", hashKey), ComponentConfigCheck),

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -14,6 +14,16 @@
 
 package fluentd
 
+const ConfigKey = "fluent.conf"
+
+var fluentdConfigCheckTemplate = `
+# include other config files
+@include /fluentd/etc/input.conf
+@include /fluentd/etc/generated.conf
+@include /fluentd/etc/devnull.conf
+@include /fluentd/etc/fluentlog.conf
+`
+
 var fluentdDefaultTemplate = `
 # include other config files
 @include /fluentd/etc/input.conf

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -14,8 +14,6 @@
 
 package fluentd
 
-const ConfigKey = "fluent.conf"
-
 var fluentdConfigCheckTemplate = `
 # include other config files
 @include /fluentd/etc/input.conf

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -88,12 +88,10 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 }
 
 func (r *Reconciler) secretConfig() (runtime.Object, reconciler.DesiredState, error) {
-
 	configMap, err := r.generateConfigSecret()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	configs := &corev1.Secret{
 		ObjectMeta: r.FluentdObjectMeta(SecretConfigName, ComponentFluentd),
 		Data:       configMap,

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -92,12 +92,11 @@ func (r *Reconciler) secretConfig() (runtime.Object, reconciler.DesiredState, er
 	if err != nil {
 		return nil, nil, err
 	}
+	configMap["fluentlog.conf"] = []byte(fmt.Sprintf(fluentLog, r.Logging.Spec.FluentdSpec.FluentLogDestination))
 	configs := &corev1.Secret{
 		ObjectMeta: r.FluentdObjectMeta(SecretConfigName, ComponentFluentd),
 		Data:       configMap,
 	}
-
-	configs.Data["fluentlog.conf"] = []byte(fmt.Sprintf(fluentLog, r.Logging.Spec.FluentdSpec.FluentLogDestination))
 
 	return configs, reconciler.StatePresent, nil
 }

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -208,7 +208,7 @@ func (r *Reconciler) Reconcile() (*reconcile.Result, error) {
 	}
 	for _, res := range []resources.Resource{
 		r.secretConfig,
-		r.configCheckConfigSecret,
+		r.appConfigSecret,
 		r.statefulset,
 		r.service,
 		r.headlessService,

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -37,6 +37,8 @@ import (
 const (
 	SecretConfigName      = "fluentd"
 	AppSecretConfigName   = "fluentd-app"
+	ConfigCheckKey        = "generated.conf"
+	ConfigKey             = "fluent.conf"
 	AppConfigKey          = "fluentd.conf"
 	StatefulSetName       = "fluentd"
 	PodSecurityPolicyName = "fluentd"

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -208,7 +208,7 @@ func (r *Reconciler) Reconcile() (*reconcile.Result, error) {
 	}
 	for _, res := range []resources.Resource{
 		r.secretConfig,
-		r.appconfigMap,
+		r.configCheckConfigSecret,
 		r.statefulset,
 		r.service,
 		r.headlessService,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #681
| License         | Apache 2.0


### What's in this PR?
Make configcheck identical to production config