### PR TITLE
Bump operator image version

### DIFF
--- a/pkg/sdk/resourcebuilder/component.go
+++ b/pkg/sdk/resourcebuilder/component.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	Image            = "ghcr.io/banzaicloud/logging-operator:3.9.5"
+	Image            = "ghcr.io/banzaicloud/logging-operator:3.10.0"
 	defaultNamespace = "logging-system"
 )
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bump image version in SDK to refer to the latest logging operator image.

