### PR TITLE
Circle CI Licensei check disabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ jobs:
             make check-diff
 
       - run:
-          name: Check licenses
-          command: |
-            make license-check
-
-      - run:
           name: Run lint
           command: make lint
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Circle CI Licensei check disabled. Now running under GH Action

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
