### PR TITLE
fix: remove windows tolerations

### DIFF
--- a/pkg/resources/nodeagent/nodeagent.go
+++ b/pkg/resources/nodeagent/nodeagent.go
@@ -231,13 +231,6 @@ var NodeAgentFluentbitWindowsDefaults = &v1beta1.NodeAgent{
 						NodeSelector: map[string]string{
 							"kubernetes.io/os": "windows",
 						},
-						Tolerations: []v1.Toleration{{
-							Key:      "node.kubernetes.io/os",
-							Operator: "Equal",
-							Value:    "windows",
-							Effect:   "NoSchedule",
-						},
-						},
 					}},
 			}},
 	},


### PR DESCRIPTION
when having default windows tolerations and setting tolerations in the
helm chart, the merge of those arrays don't work as expected.
not all clusters have taints on their windows nodes, in general
`nodeSelector` should work fine.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Removes the tolerations from the windows nodeAgent daemonset to allow users specifying them as needed.


### Why?
When having predefined tolerations and trying to specify own tolerations the merge of the slice doesn't work as expected. 
E.g. I set the following via helm chart:
```
tolerations:
  - operator: Exists
```

To allow for any taint to be tolerated. The merge of the slices then ended up in the following:
```
tolerations:
  - key: "node.kubernetes.io/os"
    operator: Exists
    value: "windows"
    effect: NoSchedule
```
Which doesn't work and is actually an error (if `Exists` operator, no value can be set). 

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
