### PR TITLE
Avoid trailing space in template

### DIFF
--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -34,9 +34,10 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          args: {{ range .Values.extraArgs }}
-            - {{ . -}}
-            {{ end }}
+          args:
+          {{- range .Values.extraArgs }}
+            - {{ . }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0

### What's in this PR?
This change avoids a trailing space in the template.

### Why?
`yamllint` flags the trailing space as an error.

### Additional context
n/a