### PR TITLE
[fix] Fields `hec_host` and `hec_port` in splunk example

### DIFF
--- a/pkg/sdk/model/output/splunk_hec.go
+++ b/pkg/sdk/model/output/splunk_hec.go
@@ -32,8 +32,8 @@ type _hugoSplunk interface{}
 // ```
 // spec:
 //   SplunkHec:
-//     host: splunk.default.svc.cluster.local
-//     port: 8088
+//     hec_host: splunk.default.svc.cluster.local
+//     hec_port: 8088
 //     protocol: http
 // ```
 type _docSplunkHec interface{}

--- a/pkg/sdk/model/output/splunk_hec.go
+++ b/pkg/sdk/model/output/splunk_hec.go
@@ -31,7 +31,7 @@ type _hugoSplunk interface{}
 // #### Example output configurations
 // ```
 // spec:
-//   SplunkHec:
+//   splunkHec:
 //     hec_host: splunk.default.svc.cluster.local
 //     hec_port: 8088
 //     protocol: http


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Updates the example in the Splunk docu to be correct.


### Why?

The field names were wrong and not consistent with the rest of the docu


### Additional context

N/A


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
