### PR TITLE
Make the disableWebhook field available when serialized

### DIFF
--- a/pkg/sdk/resourcebuilder/component.go
+++ b/pkg/sdk/resourcebuilder/component.go
@@ -60,7 +60,7 @@ type ComponentConfig struct {
 	ContainerOverrides    *types.ContainerBase `json:"containerOverrides,omitempty"`
 	WatchNamespace        string               `json:"watchNamespace,omitempty"`
 	WatchLoggingName      string               `json:"watchLoggingName,omitempty"`
-	DisableWebhook        bool                 `json:"-"`
+	DisableWebhook        bool                 `json:"disableWebhook,omitempty"`
 }
 
 func (c *ComponentConfig) IsEnabled() bool {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Make the disableWebhook field available when serialized.

### Why?
There are cases where downstream code cannot properly decide whether cert-manager is enabled or not (or simply don't want to use it) and might need to disable webhook creation to skip them, or to manage them separately.