### PR TITLE
fix(chart): add prometheusrules in clusterrole

### DIFF
--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -159,6 +159,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - prometheusrules
   verbs:
   - create
   - delete


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no|
| Related tickets | fixes #815
| License         | Apache 2.0


### What's in this PR?
logging operator 3.14 introduced the possibility to create default prometheus rules. In consequence, the chart need to deploy adapted clusterrole.

### Checklist
- [x] Related Helm chart(s) updated (if needed)

