### PR TITLE
fluent-plugin-elasticsearch opensearch fix

### DIFF
--- a/charts/logging-demo/Chart.yaml
+++ b/charts/logging-demo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "3.14.1"
+appVersion: "3.14.2"
 description: A Helm chart for Kubernetes
 name: logging-demo
-version: 3.14.1
+version: 3.14.2
 icon: https://raw.githubusercontent.com/banzaicloud/logging-operator/master/docs/img/icon.png

--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "3.14.1"
+appVersion: "3.14.2"
 description: A Helm chart to configure logging resource for the Logging operator
 name: logging-operator-logging
-version: 3.14.1
+version: 3.14.2
 icon: https://raw.githubusercontent.com/banzaicloud/logging-operator/master/docs/img/icon.png

--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                                          | `IfNotPresent`                                             |
 | `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                                   | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                                          | true                                                       |
-| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-1`                                          |
+| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-2`                                          |
 | `fluentd.image.repository`                          | Fluentd container image repository                                       | `ghcr.io/banzaicloud/fluentd`                                      |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                                            | `IfNotPresent`                                             |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag                               | `latest`                                                   |

--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.14.1"
+appVersion: "3.14.2"
 description: A Helm chart to install Banzai Cloud logging-operator
 name: logging-operator
-version: 3.14.1
+version: 3.14.2

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -49,7 +49,7 @@ The following tables lists the configurable parameters of the logging-operator c
 |                      Parameter                      |                        Description                     |             Default            |
 | --------------------------------------------------- | ------------------------------------------------------ | ------------------------------ |
 | `image.repository`                                  | Container image repository                             | `ghcr.io/banzaicloud/logging-operator` |
-| `image.tag`                                         | Container image tag                                    | `3.14.1`                        |
+| `image.tag`                                         | Container image tag                                    | `3.14.2`                        |
 | `image.pullPolicy`                                  | Container pull policy                                  | `IfNotPresent`                 |
 | `nameOverride`                                      | Override name of app                                   | ``                             |
 | `fullnameOverride`                                  | Override full name of app                              | ``                             |
@@ -116,7 +116,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                           |
-| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-1`             |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-2`             |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `ghcr.io/banzaicloud/fluentd`  |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/banzaicloud/logging-operator
-  tag: 3.14.1
+  tag: 3.14.2
   pullPolicy: IfNotPresent
 
 extraArgs:

--- a/fluentd-image/v1.13/Dockerfile
+++ b/fluentd-image/v1.13/Dockerfile
@@ -32,11 +32,11 @@ RUN apk update \
  && gem install bigdecimal -v 1.4.4 \
  && gem install webrick \
  && gem install gelf -v 3.0.0 \
+ && gem install fluent-plugin-elasticsearch -v 5.0.5 \
  && gem install \
          specific_install \
          fluent-plugin-remote-syslog \
          fluent-plugin-webhdfs \
-         fluent-plugin-elasticsearch \
          fluent-plugin-prometheus \
          fluent-plugin-s3 \
          fluent-plugin-rewrite-tag-filter \

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -116,7 +116,7 @@ const (
 	DefaultFluentbitImageRepository         = "fluent/fluent-bit"
 	DefaultFluentbitImageTag                = "1.8.5"
 	DefaultFluentdImageRepository           = "ghcr.io/banzaicloud/fluentd"
-	DefaultFluentdImageTag                  = "v1.13.3-alpine-1"
+	DefaultFluentdImageTag                  = "v1.13.3-alpine-2"
 	DefaultFluentdBufferStorageVolumeName   = "fluentd-buffer"
 	DefaultFluentdDrainWatchImageRepository = "ghcr.io/banzaicloud/fluentd-drain-watch"
 	DefaultFluentdDrainWatchImageTag        = "v0.0.1"

--- a/pkg/sdk/model/output/elasticsearch.go
+++ b/pkg/sdk/model/output/elasticsearch.go
@@ -44,8 +44,8 @@ type _hugoElasticsearch interface{}
 type _docElasticsearch interface{}
 
 // +name:"Elasticsearch"
-// +url:"https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v5.1.0"
-// +version:"5.1.0"
+// +url:"https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v5.0.5"
+// +version:"5.0.5"
 // +description:"Send your logs to Elasticsearch"
 // +status:"GA"
 type _metaElasticsearch interface{}

--- a/pkg/sdk/resourcebuilder/component.go
+++ b/pkg/sdk/resourcebuilder/component.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	Image            = "ghcr.io/banzaicloud/logging-operator:3.14.1"
+	Image            = "ghcr.io/banzaicloud/logging-operator:3.14.2"
 	defaultNamespace = "logging-system"
 )
 


### PR DESCRIPTION
- fluent-plugin-elasticsearch version rollback 5.1.5 -> 5.0.5
- release version bump 3.14.2

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0



### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
