### PR TITLE
fluent-plugin-elasticsearch opensearch fix (#821)

### DIFF
--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                                          | `IfNotPresent`                                             |
 | `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                                   | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                                          | true                                                       |
-| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-2`                                          |
+| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-4`                                          |
 | `fluentd.image.repository`                          | Fluentd container image repository                                       | `ghcr.io/banzaicloud/fluentd`                                      |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                                            | `IfNotPresent`                                             |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag                               | `latest`                                                   |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -116,7 +116,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                           |
-| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-2`             |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-4`             |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `ghcr.io/banzaicloud/fluentd`  |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |

--- a/fluentd-image/v1.13/Dockerfile
+++ b/fluentd-image/v1.13/Dockerfile
@@ -32,7 +32,10 @@ RUN apk update \
  && gem install bigdecimal -v 1.4.4 \
  && gem install webrick \
  && gem install gelf -v 3.0.0 \
- && gem install fluent-plugin-elasticsearch -v 5.0.5 \
+ # Pin the elasticsearch-ruby library < 7.14.
+ # See https://github.com/uken/fluent-plugin-elasticsearch/issues/912
+ && gem install elasticsearch -v 7.13.3 \
+ && gem install elasticsearch-xpack -v 7.13.3 \
  && gem install \
          specific_install \
          fluent-plugin-remote-syslog \
@@ -57,7 +60,7 @@ RUN apk update \
          fluent-plugin-record-modifier \
          fluent-plugin-splunk-hec \
          fluent-plugin-newrelic \
-         elasticsearch-xpack \
+         fluent-plugin-elasticsearch \
          fluent-plugin-cloudwatch-logs \
          fluent-plugin-throttle \
          fluent-plugin-logdna \

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -116,7 +116,7 @@ const (
 	DefaultFluentbitImageRepository         = "fluent/fluent-bit"
 	DefaultFluentbitImageTag                = "1.8.5"
 	DefaultFluentdImageRepository           = "ghcr.io/banzaicloud/fluentd"
-	DefaultFluentdImageTag                  = "v1.13.3-alpine-2"
+	DefaultFluentdImageTag                  = "v1.13.3-alpine-4"
 	DefaultFluentdBufferStorageVolumeName   = "fluentd-buffer"
 	DefaultFluentdDrainWatchImageRepository = "ghcr.io/banzaicloud/fluentd-drain-watch"
 	DefaultFluentdDrainWatchImageTag        = "v0.0.1"


### PR DESCRIPTION
- fluent-plugin-elasticsearch version rollback 5.1.5 -> 5.0.5
- release version bump 3.14.2

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0



### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
