### PR TITLE
Default metrics labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1
+	k8s.io/klog/v2 v2.8.0
 	sigs.k8s.io/controller-runtime v0.9.0
 )
 

--- a/pkg/sdk/model/types/builder.go
+++ b/pkg/sdk/model/types/builder.go
@@ -15,6 +15,8 @@
 package types
 
 import (
+	"encoding/json"
+
 	"emperror.dev/errors"
 )
 
@@ -66,6 +68,11 @@ func (s *SystemBuilder) RegisterDefaultFlow(f *Flow) error {
 	}
 	s.flows = append(s.flows, f)
 	s.router.Params["default_route"] = f.FlowLabel
+	metricsLabels, err := json.Marshal(map[string]string{"id": f.FlowID})
+	if err != nil {
+		return errors.Wrapf(err, "marshaling default_metrics_labels")
+	}
+	s.router.Params["default_metrics_labels"] = string(metricsLabels)
 	return nil
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially fixes #825 
| License         | Apache 2.0


### What's in this PR?
Add default_metrics_labels for the default route with the flow id.

### Why?
Because right now the default flow id is not available in the metrics when metrics is enabled for fluentd. Along with https://github.com/banzaicloud/fluent-plugin-label-router/issues/16 it actually fails and unable to process messages.

