### PR TITLE
Enable support for new ES data stream parameters

### DIFF
--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                                          | `IfNotPresent`                                             |
 | `fluentbit.podPriorityClassName`                    | Priority class name for fluentbit pods                                   | none                                                       |
 | `fluentd.enabled`                                   | Install fluentd                                                          | true                                                       |
-| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-9`                                          |
+| `fluentd.image.tag`                                 | Fluentd container image tag                                              | `v1.13.3-alpine-10`                                        |
 | `fluentd.image.repository`                          | Fluentd container image repository                                       | `ghcr.io/banzaicloud/fluentd`                                      |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                                            | `IfNotPresent`                                             |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag                               | `latest`                                                   |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -116,7 +116,7 @@ The following tables lists the configurable parameters of the logging-operator-l
 | `fluentbit.image.repository`                        | Fluentbit container image repository                   | `fluent/fluent-bit`            |
 | `fluentbit.image.pullPolicy`                        | Fluentbit container pull policy                        | `IfNotPresent`                 |
 | `fluentd.enabled`                                   | Install fluentd                                        | true                           |
-| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-9`             |
+| `fluentd.image.tag`                                 | Fluentd container image tag                            | `v1.13.3-alpine-10`            |
 | `fluentd.image.repository`                          | Fluentd container image repository                     | `ghcr.io/banzaicloud/fluentd`  |
 | `fluentd.image.pullPolicy`                          | Fluentd container pull policy                          | `IfNotPresent`                 |
 | `fluentd.volumeModImage.tag`                        | Fluentd volumeModImage container image tag             | `latest`                       |

--- a/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -1172,6 +1172,10 @@ spec:
                     type: boolean
                   data_stream_name:
                     type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
+                    type: string
                   default_elasticsearch_version:
                     type: string
                   deflector_alias:
@@ -6063,6 +6067,10 @@ spec:
                   data_stream_enable:
                     type: boolean
                   data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
                     type: string
                   default_elasticsearch_version:
                     type: string

--- a/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -1172,6 +1172,10 @@ spec:
                     type: boolean
                   data_stream_name:
                     type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
+                    type: string
                   default_elasticsearch_version:
                     type: string
                   deflector_alias:
@@ -6057,6 +6061,10 @@ spec:
                   data_stream_enable:
                     type: boolean
                   data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
                     type: string
                   default_elasticsearch_version:
                     type: string

--- a/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
@@ -1172,6 +1172,10 @@ spec:
                     type: boolean
                   data_stream_name:
                     type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
+                    type: string
                   default_elasticsearch_version:
                     type: string
                   deflector_alias:
@@ -6063,6 +6067,10 @@ spec:
                   data_stream_enable:
                     type: boolean
                   data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
                     type: string
                   default_elasticsearch_version:
                     type: string

--- a/config/crd/bases/logging.banzaicloud.io_outputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_outputs.yaml
@@ -1172,6 +1172,10 @@ spec:
                     type: boolean
                   data_stream_name:
                     type: string
+                  data_stream_template_name:
+                    type: string
+                  data_stream_ilm_name:
+                    type: string
                   default_elasticsearch_version:
                     type: string
                   deflector_alias:

--- a/pkg/sdk/api/v1beta1/logging_types.go
+++ b/pkg/sdk/api/v1beta1/logging_types.go
@@ -116,7 +116,7 @@ const (
 	DefaultFluentbitImageRepository         = "fluent/fluent-bit"
 	DefaultFluentbitImageTag                = "1.8.5"
 	DefaultFluentdImageRepository           = "ghcr.io/banzaicloud/fluentd"
-	DefaultFluentdImageTag                  = "v1.13.3-alpine-9"
+	DefaultFluentdImageTag                  = "v1.13.3-alpine-10"
 	DefaultFluentdBufferStorageVolumeName   = "fluentd-buffer"
 	DefaultFluentdDrainWatchImageRepository = "ghcr.io/banzaicloud/fluentd-drain-watch"
 	DefaultFluentdDrainWatchImageTag        = "v0.0.1"

--- a/pkg/sdk/model/output/elasticsearch.go
+++ b/pkg/sdk/model/output/elasticsearch.go
@@ -240,6 +240,10 @@ type ElasticsearchOutput struct {
 	DataStreamEnable *bool `json:"data_stream_enable,omitempty"`
 	// You can specify Elasticsearch data stream name by this parameter. This parameter is mandatory for elasticsearch_data_stream. There are some limitations about naming rule. For more details https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html#indices-create-data-stream-api-path-params
 	DataStreamName string `json:"data_stream_name,omitempty"`
+	// Specify an existing index template for the data stream. If not present, a new template is created and named after the data stream. (default: data_stream_name) Further details here https://github.com/uken/fluent-plugin-elasticsearch#configuration---elasticsearch-output-data-stream
+	DataStreamName string `json:"data_stream_template_name,omitempty"`
+	// Specify an existing ILM policy to be applied to the data stream. If not present, either the specified template's or a new ILM default policy is applied. (default: data_stream_name) Further details here https://github.com/uken/fluent-plugin-elasticsearch#configuration---elasticsearch-output-data-stream
+	DataStreamName string `json:"data_stream_ilm_name,omitempty"`
 }
 
 func (e *ElasticsearchOutput) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Enables support for two optional parameters which were recently 
added to the ES plugin. The parameters allow to specify the name 
of existing index template and/or ILM policy.


### Why?
Integration with the new ES plugin feature enabled in [this PR](https://github.com/uken/fluent-plugin-elasticsearch/pull/920).


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
