### PR TITLE
tag EnabledComponent as inline for controller-gen

### DIFF
--- a/pkg/sdk/resourcebuilder/component.go
+++ b/pkg/sdk/resourcebuilder/component.go
@@ -53,7 +53,7 @@ const (
 // +kubebuilder:object:generate=true
 
 type ComponentConfig struct {
-	types.EnabledComponent
+	types.EnabledComponent `json:",inline"`
 	Namespace              string               `json:"namespace,omitempty"`
 	MetaOverrides          *types.MetaBase      `json:"metaOverrides,omitempty"`
 	WorkloadMetaOverrides  *types.MetaBase      `json:"workloadMetaOverrides,omitempty"`


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Tag `EnabledComponent` as *inline* for controller-gen.

### Why?
Without the tag controller-gen will fail to process `ComponentConfig`. This problem doesn't surface in this codebase but third-party users of the pkg/sdk might run into this.