### PR TITLE
Add pods to fluentd cluster role

### DIFF
--- a/pkg/resources/fluentd/rbac.go
+++ b/pkg/resources/fluentd/rbac.go
@@ -86,6 +86,7 @@ func (r *Reconciler) clusterRole() (runtime.Object, reconciler.DesiredState, err
 						"nodes",
 						"endpoints",
 						"services",
+						"pods",
 					},
 					Verbs: []string{"get", "list", "watch"},
 				}, {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #862 
| License         | Apache 2.0


### What's in this PR?
Simply adds the pods resource to the FluentD cluster role


### Why?
The enhanceK8s filter plugin requires this access



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

