### PR TITLE
Remove extensions API

### DIFF
--- a/pkg/resources/fluentd/rbac.go
+++ b/pkg/resources/fluentd/rbac.go
@@ -100,14 +100,6 @@ func (r *Reconciler) clusterRole() (runtime.Object, reconciler.DesiredState, err
 					Verbs: []string{"get", "list", "watch"},
 				},
 				{
-					APIGroups: []string{"extensions"},
-					Resources: []string{
-						"deployments",
-					},
-					Verbs: []string{"get", "list", "watch"},
-				},
-
-				{
 					APIGroups: []string{"events.k8s.io"},
 					Resources: []string{
 						"events",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
This removes the Extensions API from the ClusterRole for Fluentd.  This was used for Deployments permissions


### Why?
The deployments extensions API has been removed from k8s as of v1.16.  It should no longer be required.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

