### PR TITLE
Fix fluentbit multiline

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -49,7 +49,7 @@ var fluentBitConfigTemplate = `
     {{- end }}
     {{- end }}
     {{- if .Input.MultilineParser }}
-    multiline.parser: {{- range $i, $v := .Input.MultilineParser }}{{ if $i }},{{ end}} {{ $v }}{{ end }}
+    multiline.parser {{- range $i, $v := .Input.MultilineParser }}{{ if $i }},{{ end}} {{ $v }}{{ end }}
     {{- end }}
 
 {{- if not .DisableKubernetesFilter }}

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -134,14 +134,31 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 	// FluentBit input Values
 	fluentbitInput := fluentbitInputConfig{}
 	inputTail := r.Logging.Spec.FluentbitSpec.InputTail
-	if len(inputTail.ParserN) > 0 {
-		fluentbitInput.ParserN = r.Logging.Spec.FluentbitSpec.InputTail.ParserN
+
+	if len(inputTail.MultilineParser) > 0 {
+		fluentbitInput.MultilineParser = inputTail.MultilineParser
+		inputTail.MultilineParser = nil
+
+		// If MultilineParser is set, remove other parser fields
+		// See https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-core-v1.8
+
+		log.Log.Info("Notice: MultilineParser is enabled. Disabling other parser options",
+			"logging", r.Logging.Name)
+
+		inputTail.Parser = ""
+		inputTail.ParserFirstline = ""
+		inputTail.ParserN = nil
+		inputTail.Multiline = ""
+		inputTail.MultilineFlush = ""
+		inputTail.DockerMode = ""
+		inputTail.DockerModeFlush = ""
+		inputTail.DockerModeParser = ""
+
+	} else if len(inputTail.ParserN) > 0 {
+		fluentbitInput.ParserN = inputTail.ParserN
 		inputTail.ParserN = nil
 	}
-	if len(inputTail.MultilineParser) > 0 {
-		fluentbitInput.MultilineParser = r.Logging.Spec.FluentbitSpec.InputTail.MultilineParser
-		inputTail.MultilineParser = nil
-	}
+
 	fluentbitInputValues, err := mapper.StringsMap(inputTail)
 	if err != nil {
 		return nil, reconciler.StatePresent, errors.WrapIf(err, "failed to map container tailer config for fluentbit")

--- a/pkg/resources/nodeagent/config.go
+++ b/pkg/resources/nodeagent/config.go
@@ -44,7 +44,7 @@ var fluentBitConfigTemplate = `
     {{- end }}
     {{- end }}
     {{- if .Input.MultilineParser }}
-    multiline.parser: {{- range $i, $v := .Input.MultilineParser }}{{ if $i }},{{ end}} {{ $v }}{{ end }}
+    multiline.parser {{- range $i, $v := .Input.MultilineParser }}{{ if $i }},{{ end}} {{ $v }}{{ end }}
     {{- end }}
 
 {{- if not .DisableKubernetesFilter }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #888 
| License         | Apache 2.0


### What's in this PR?
Change the way fluentbit configuration is generated when multiline.parser field is used.


### Why?
Currently the operator generates an invalid configuration for fluentbit when multiline.parser field is used.
There are two problems with the generated configuration:
- A typo (an extra `:` char)
- An extra statement `Parser crio` in the INPUT section of the configuration. Because Parser field has a default value based on the contianer runtime environment, it is always rendered in the configuration.
The multiline.parser documentation (see https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-core-v1.8 ) states that 

> Note that when using a new multiline.parser definition, you must disable the old configuration from your tail section like:
> - parser
> - parser_firstline
> - parser_N
> - multiline
> - multiline_flush
> - docker_mode

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### To Do
- Not sure if I can use reflection to get field names
- A log message when/if multiline parser is used, stating the other parsers will be disabled.
