### PR TITLE
chore: move default images repositories and tags to globals

### DIFF
--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -113,15 +113,21 @@ type DefaultFlowSpec struct {
 }
 
 const (
-	DefaultFluentbitImageRepository         = "fluent/fluent-bit"
-	DefaultFluentbitImageTag                = "1.8.9"
-	DefaultFluentdImageRepository           = "ghcr.io/banzaicloud/fluentd"
-	DefaultFluentdImageTag                  = "v1.14.4-alpine-1"
-	DefaultFluentdBufferStorageVolumeName   = "fluentd-buffer"
-	DefaultFluentdDrainWatchImageRepository = "ghcr.io/banzaicloud/fluentd-drain-watch"
-	DefaultFluentdDrainWatchImageTag        = "v0.0.1"
-	DefaultFluentdDrainPauseImageRepository = "k8s.gcr.io/pause"
-	DefaultFluentdDrainPauseImageTag        = "latest"
+	DefaultFluentbitImageRepository             = "fluent/fluent-bit"
+	DefaultFluentbitImageTag                    = "1.8.9"
+	DefaultFluentdImageRepository               = "ghcr.io/banzaicloud/fluentd"
+	DefaultFluentdImageTag                      = "v1.14.4-alpine-1"
+	DefaultFluentdBufferStorageVolumeName       = "fluentd-buffer"
+	DefaultFluentdDrainWatchImageRepository     = "ghcr.io/banzaicloud/fluentd-drain-watch"
+	DefaultFluentdDrainWatchImageTag            = "v0.0.1"
+	DefaultFluentdDrainPauseImageRepository     = "k8s.gcr.io/pause"
+	DefaultFluentdDrainPauseImageTag            = "latest"
+	DefaultFluentdVolumeModeImageRepository     = "busybox"
+	DefaultFluentdVolumeModeImageTag            = "latest"
+	DefaultFluentdConfigReloaderImageRepository = "jimmidyson/configmap-reload"
+	DefaultFluentdConfigReloaderImageTag        = "v0.4.0"
+	DefaultFluentdBufferVolumeImageRepository   = "quay.io/prometheus/node-exporter"
+	DefaultFluentdBufferVolumeImageTag          = "v1.1.2"
 )
 
 // SetDefaults fills empty attributes
@@ -206,28 +212,28 @@ func (l *Logging) SetDefaults() error {
 			}
 		}
 		if l.Spec.FluentdSpec.VolumeModImage.Repository == "" {
-			l.Spec.FluentdSpec.VolumeModImage.Repository = "busybox"
+			l.Spec.FluentdSpec.VolumeModImage.Repository = DefaultFluentdVolumeModeImageRepository
 		}
 		if l.Spec.FluentdSpec.VolumeModImage.Tag == "" {
-			l.Spec.FluentdSpec.VolumeModImage.Tag = "latest"
+			l.Spec.FluentdSpec.VolumeModImage.Tag = DefaultFluentdVolumeModeImageTag
 		}
 		if l.Spec.FluentdSpec.VolumeModImage.PullPolicy == "" {
 			l.Spec.FluentdSpec.VolumeModImage.PullPolicy = "IfNotPresent"
 		}
 		if l.Spec.FluentdSpec.ConfigReloaderImage.Repository == "" {
-			l.Spec.FluentdSpec.ConfigReloaderImage.Repository = "jimmidyson/configmap-reload"
+			l.Spec.FluentdSpec.ConfigReloaderImage.Repository = DefaultFluentdConfigReloaderImageRepository
 		}
 		if l.Spec.FluentdSpec.ConfigReloaderImage.Tag == "" {
-			l.Spec.FluentdSpec.ConfigReloaderImage.Tag = "v0.4.0"
+			l.Spec.FluentdSpec.ConfigReloaderImage.Tag = DefaultFluentdConfigReloaderImageTag
 		}
 		if l.Spec.FluentdSpec.ConfigReloaderImage.PullPolicy == "" {
 			l.Spec.FluentdSpec.ConfigReloaderImage.PullPolicy = "IfNotPresent"
 		}
 		if l.Spec.FluentdSpec.BufferVolumeImage.Repository == "" {
-			l.Spec.FluentdSpec.BufferVolumeImage.Repository = "quay.io/prometheus/node-exporter"
+			l.Spec.FluentdSpec.BufferVolumeImage.Repository = DefaultFluentdBufferVolumeImageRepository
 		}
 		if l.Spec.FluentdSpec.BufferVolumeImage.Tag == "" {
-			l.Spec.FluentdSpec.BufferVolumeImage.Tag = "v1.1.2"
+			l.Spec.FluentdSpec.BufferVolumeImage.Tag = DefaultFluentdBufferVolumeImageTag
 		}
 		if l.Spec.FluentdSpec.BufferVolumeImage.PullPolicy == "" {
 			l.Spec.FluentdSpec.BufferVolumeImage.PullPolicy = "IfNotPresent"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Move default fluentd sidecar images to external global variables

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
So it ease readability of the current supported images for a given version of logging operator

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
