### PR TITLE
fix(dashboard): update to latest kube_pod_container_resource metrics

### DIFF
--- a/config/dashboards/logging-dashboard.json
+++ b/config/dashboards/logging-dashboard.json
@@ -639,7 +639,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable_cpu_cores{cluster=\"$cluster\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\", cluster=\"$cluster\"})",
           "instant": false,
           "refId": "A"
         }
@@ -730,7 +730,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable_cpu_cores{cluster=\"$cluster\"})",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\", cluster=\"$cluster\"})",
           "instant": false,
           "refId": "A"
         }
@@ -1271,7 +1271,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable_memory_bytes{cluster=\"$cluster\"})",
+          "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", cluster=\"$cluster\"})",
           "instant": false,
           "refId": "A"
         }
@@ -1362,7 +1362,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable_memory_bytes{cluster=\"$cluster\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", cluster=\"$cluster\"})",
           "instant": false,
           "refId": "A"
         }
@@ -1453,7 +1453,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable_memory_bytes{cluster=\"$cluster\"})",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", cluster=\"$cluster\"})",
           "instant": false,
           "refId": "A"
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update the dashboard to use the replacement for kube-state-metrics deprecated metrics.
 
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
These metrics where removed several releases ago which makes the dashboard show N/A values.
See https://github.com/kubernetes/kube-state-metrics/tree/release-1.9/docs#metrics-deprecation

![image](https://user-images.githubusercontent.com/8191198/156564195-fb07d661-ace2-45d2-8ed3-593d7ae3b10d.png)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
