### PR TITLE
Match statefulset immutable errors

### DIFF
--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -86,6 +86,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	reconcilerOpts := reconciler.ReconcilerOpts{
+		RecreateErrorMessageCondition:                reconciler.MatchImmutableErrorMessages,
 		EnableRecreateWorkloadOnImmutableFieldChange: logging.Spec.EnableRecreateWorkloadOnImmutableFieldChange,
 		EnableRecreateWorkloadOnImmutableFieldChangeHelp: "Object has to be recreated, but refusing to remove without explicitly being told so. " +
 			"Use logging.spec.enableRecreateWorkloadOnImmutableFieldChange to move on but make sure to understand the consequences. " +


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related https://github.com/banzaicloud/logging-operator/issues/918
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Set RecreateErrorMessageCondition to MatchImmutableErrorMessages
 			
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Statefulset immutable errors should be detected.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This PR may be optional if https://github.com/banzaicloud/operator-tools/pull/103 is merged.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
