### PR TITLE
Addingwatch Namespaces in logging-operator-logging Helm chart

### DIFF
--- a/charts/logging-operator-logging/templates/logging.yaml
+++ b/charts/logging-operator-logging/templates/logging.yaml
@@ -20,6 +20,10 @@ spec:
   {{- with .Values.allowClusterResourcesFromAllNamespaces }}
   allowClusterResourcesFromAllNamespaces: {{ . }}
   {{- end }}
+  {{- if .Values.watchNamespaces }}
+  watchNamespaces:
+{{ toYaml .Values.watchNamespaces | indent 4 }}
+  {{- end }}
   controlNamespace: {{ .Values.controlNamespace | default .Release.Namespace }}
   {{- if .Values.defaultFlow }}
   defaultFlow:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in (https://community-banzaicloud.slack.com/archives/CGMPPBZBK/p1646652613931739)
| License         | Apache 2.0


### What's in this PR?
Adding watchNamespaces in logging-operator-logging Helm chart

### Why?
watchNamespaces variable is not in the logging CRD

### Additional context
we will need to QA


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
