### PR TITLE
Addingwatch Namespaces in logging-operator-logging Helm chart 

### DIFF
--- a/charts/logging-operator-logging/templates/logging.yaml
+++ b/charts/logging-operator-logging/templates/logging.yaml
@@ -20,6 +20,10 @@ spec:
   {{- with .Values.allowClusterResourcesFromAllNamespaces }}
   allowClusterResourcesFromAllNamespaces: {{ . }}
   {{- end }}
+  {{- if .Values.watchNamespaces }}
+  watchNamespaces:
+{{ toYaml .Values.watchNamespaces | indent 4 }}
+  {{- end }}
   controlNamespace: {{ .Values.controlNamespace | default .Release.Namespace }}
   {{- if .Values.defaultFlow }}
   defaultFlow:

--- a/charts/logging-operator-logging/values.yaml
+++ b/charts/logging-operator-logging/values.yaml
@@ -64,7 +64,7 @@ tls:
   fluentbitSecretName: ""
   fluentdSecretName: ""
 
-# Limit namespaces from where to read Flow and Output specs
+# Control and limit namespaces from where to read Flow and Output specs
 watchNamespaces: []
 # Control namespace that contains ClusterOutput and ClusterFlow resources
 controlNamespace: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in (https://community-banzaicloud.slack.com/archives/CGMPPBZBK/p1646652613931739)
| License         | Apache 2.0


### What's in this PR?
I am adding that variable to be able to continue using the offical HELM CHART instead my own fork that I am using now
 
I was trying to add the variable watchNamespaces using the helm chart but I realized that this variable it was not mapped in the yaml. 

Adding watchNamespaces in logging-operator-logging Helm chart

### Why?
watchNamespaces variable is not in the logging CRD


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
