### PR TITLE
Fix Nil Pointer Panic around configsecret Reconciler

### DIFF
--- a/pkg/resources/nodeagent/configsecret.go
+++ b/pkg/resources/nodeagent/configsecret.go
@@ -234,6 +234,10 @@ func (n *nodeAgentInstance) configSecret() (runtime.Object, reconciler.DesiredSt
 		}
 	}
 
+	if nil == n.fluentdDataProvider {
+		return nil, nil, errors.WrapIf(err, "nil fluent data provider")
+	}
+
 	fluentdReplicas, err := n.fluentdDataProvider.GetReplicaCount(context.TODO(), n.logging)
 	if err != nil {
 		return nil, nil, errors.WrapIf(err, "getting replica count for fluentd")

--- a/pkg/resources/nodeagent/nodeagent.go
+++ b/pkg/resources/nodeagent/nodeagent.go
@@ -317,9 +317,10 @@ func (r *Reconciler) Reconcile() (*reconcile.Result, error) {
 		}
 
 		instance = nodeAgentInstance{
-			nodeAgent:  NodeAgentFluentbitDefaults,
-			reconciler: r.GenericResourceReconciler,
-			logging:    r.Logging,
+			nodeAgent:           NodeAgentFluentbitDefaults,
+			reconciler:          r.GenericResourceReconciler,
+			logging:             r.Logging,
+			fluentdDataProvider: r.fluentdDataProvider,
 		}
 
 		result, err := instance.Reconcile()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixed #920 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add nil pointer checker around `nodeAgentInstance.fluentdDataProvider` and make sure it's passed in when nodeInstanceAgent is created. Stems from using it here: https://github.com/banzaicloud/logging-operator/blob/master/pkg/resources/nodeagent/configsecret.go#L237 and it never being set here: https://github.com/banzaicloud/logging-operator/blob/master/pkg/resources/nodeagent/nodeagent.go#L319-L323

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
causing a panic when trying to access a nil pointer

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
when the instance was setup it was forgotten to pass the main reconcile fluentDataProvider down to the subsequent reconcilers. The only one that apparently used it was configsecret which only shows up when you use a secret to setup your output.



### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)

