### PR TITLE
removing bufferVolumeMetrics sidecar from drainer job so it can complete

### DIFF
--- a/pkg/resources/fluentd/drainjob.go
+++ b/pkg/resources/fluentd/drainjob.go
@@ -35,9 +35,6 @@ func (r *Reconciler) drainerJobFor(pvc corev1.PersistentVolumeClaim) (*batchv1.J
 		fluentdContainer,
 		drainWatchContainer(&r.Logging.Spec.FluentdSpec.Scaling.Drain, bufVolName),
 	}
-	if c := r.bufferMetricsSidecarContainer(); c != nil {
-		containers = append(containers, *c)
-	}
 
 	spec := batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #952 
| License         | Apache 2.0


### What's in this PR?

remove bufferVolumeMetrics sidecar from drainer job as its a daemon and will never exit which prevents the job from ever completing

### Why?

drainer job can never complete. 


### Additional context

I don't believe the metrics exposed by the drainer job can be picked up by prometheus anyway, and if they could should they?


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
