### PR TITLE
Fix statefulset recreate loop

### DIFF
--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -47,6 +47,7 @@ func (r *Reconciler) daemonSet() (runtime.Object, reconciler.DesiredState, error
 
 	labels := util.MergeLabels(r.Logging.Spec.FluentbitSpec.Labels, r.getFluentBitLabels())
 	meta := r.FluentbitObjectMeta(fluentbitDaemonSetName)
+	meta.Annotations = util.MergeLabels(meta.Annotations, r.Logging.Spec.FluentbitSpec.DaemonSetAnnotations)
 	podMeta := metav1.ObjectMeta{
 		Labels:      labels,
 		Annotations: r.Logging.Spec.FluentbitSpec.Annotations,

--- a/pkg/resources/fluentbit/meta.go
+++ b/pkg/resources/fluentbit/meta.go
@@ -36,7 +36,7 @@ func (r *Reconciler) FluentbitObjectMeta(name string) metav1.ObjectMeta {
 			},
 		},
 	}
-	return o
+	return *o.DeepCopy()
 }
 
 // FluentbitObjectMetaClusterScope creates an cluster scoped objectMeta for resource fluentbit

--- a/pkg/resources/fluentbit/meta.go
+++ b/pkg/resources/fluentbit/meta.go
@@ -22,10 +22,9 @@ import (
 // FluentbitObjectMeta creates an objectMeta for resource fluentbit
 func (r *Reconciler) FluentbitObjectMeta(name string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
-		Name:        r.Logging.QualifiedName(name),
-		Namespace:   r.Logging.Spec.ControlNamespace,
-		Labels:      r.getFluentBitLabels(),
-		Annotations: r.Logging.Spec.FluentbitSpec.DaemonSetAnnotations,
+		Name:      r.Logging.QualifiedName(name),
+		Namespace: r.Logging.Spec.ControlNamespace,
+		Labels:    r.getFluentBitLabels(),
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: r.Logging.APIVersion,

--- a/pkg/resources/fluentd/meta.go
+++ b/pkg/resources/fluentd/meta.go
@@ -36,7 +36,7 @@ func (r *Reconciler) FluentdObjectMeta(name, component string) metav1.ObjectMeta
 			},
 		},
 	}
-	return o
+	return *o.DeepCopy()
 }
 
 // FluentdObjectMetaClusterScope creates an objectMeta for resource fluentd

--- a/pkg/resources/fluentd/meta.go
+++ b/pkg/resources/fluentd/meta.go
@@ -22,10 +22,9 @@ import (
 // FluentdObjectMeta creates an objectMeta for resource fluentd
 func (r *Reconciler) FluentdObjectMeta(name, component string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
-		Name:        r.Logging.QualifiedName(name),
-		Namespace:   r.Logging.Spec.ControlNamespace,
-		Labels:      r.Logging.GetFluentdLabels(component),
-		Annotations: r.Logging.Spec.FluentdSpec.StatefulSetAnnotations,
+		Name:      r.Logging.QualifiedName(name),
+		Namespace: r.Logging.Spec.ControlNamespace,
+		Labels:    r.Logging.GetFluentdLabels(component),
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: r.Logging.APIVersion,

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -58,6 +58,8 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 		Spec:       *spec,
 	}
 
+	desired.Annotations = util.MergeLabels(desired.Annotations, r.Logging.Spec.FluentdSpec.StatefulSetAnnotations)
+
 	return desired, reconciler.StatePresent, nil
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #959, closes #960 
| License         | Apache 2.0


### What's in this PR?
Fix #959 by returning a deep copy of the object metadata assembled by `FluentdObjectMeta` and `FluentbitObjectMeta`.
Also, stop adding `statefulsetAnnotations` and `daemonsetAnnotations` to resources other than the Fluentd statefulset and Fluentbit daemonset.

### Why?
Adding the annotation maps from the config in e3b340132bc4658271c8934e13e1c8a5a1ae6cc6 to the object metadata caused sharing between resources which resulted in action-at-a-distance. 


