### PR TITLE
Node exporter custom runner for drainer job

### DIFF
--- a/drain-watch-image/drain-watch.sh
+++ b/drain-watch-image/drain-watch.sh
@@ -2,6 +2,7 @@
 
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
 RPC_ADDRESS="${RPC_ADDRESS:-127.0.0.1:24444}"
+CUSTOM_RUNNER_ADDRESS="${CUSTOM_RUNNER_ADDRESS:-127.0.0.1:7357}"
 
 [ -z "$BUFFER_PATH" ] && exit 2
 
@@ -21,6 +22,7 @@ do
 
   if [ "$(find $BUFFER_PATH -iname '*.buffer' -or -iname '*.buffer.meta' | wc -l)" = 0 ]
   then
+    echo '['$(date)']' 'exiting node exporter custom runner:' "$(curl --silent --show-error http://$CUSTOM_RUNNER_ADDRESS/exit)"
     echo '['$(date)']' 'no buffers left, terminating workers:' "$(curl --silent --show-error http://$RPC_ADDRESS/api/processes.killWorkers)"
     exit 0
   fi

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -37,15 +37,15 @@ func WithCluster(t *testing.T, fn func(*testing.T, Cluster), opts ...cluster.Opt
 	cluster, err := GetTestCluster(defaultClusterName, opts...)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, _ := context.WithCancel(context.Background())
 	go func() {
 		require.NoError(t, cluster.Start(ctx))
 	}()
 
-	defer func() {
-		cancel()
-		require.NoError(t, DeleteTestCluster(defaultClusterName))
-	}()
+	// defer func() {
+	// 	cancel()
+	// 	require.NoError(t, DeleteTestCluster(defaultClusterName))
+	// }()
 
 	fn(t, cluster)
 }

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -37,15 +37,15 @@ func WithCluster(t *testing.T, fn func(*testing.T, Cluster), opts ...cluster.Opt
 	cluster, err := GetTestCluster(defaultClusterName, opts...)
 	require.NoError(t, err)
 
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		require.NoError(t, cluster.Start(ctx))
 	}()
 
-	// defer func() {
-	// 	cancel()
-	// 	require.NoError(t, DeleteTestCluster(defaultClusterName))
-	// }()
+	defer func() {
+		cancel()
+		require.NoError(t, DeleteTestCluster(defaultClusterName))
+	}()
 
 	fn(t, cluster)
 }

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -81,6 +81,9 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("50M"),
 						},
 					},
+					BufferVolumeMetrics: &v1beta1.Metrics{
+						// ServiceMonitor: true,
+					},
 					Scaling: &v1beta1.FluentdScaling{
 						Replicas: 2,
 						Drain: v1beta1.FluentdDrainConfig{

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -81,9 +81,7 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("50M"),
 						},
 					},
-					BufferVolumeMetrics: &v1beta1.Metrics{
-						// ServiceMonitor: true,
-					},
+					BufferVolumeMetrics: &v1beta1.Metrics{},
 					Scaling: &v1beta1.FluentdScaling{
 						Replicas: 2,
 						Drain: v1beta1.FluentdDrainConfig{
@@ -172,13 +170,13 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 			return present && job.Status.Active > 0
 		}, 2*time.Minute, 1*time.Second)
 
-		require.Eventually(t, cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 5*time.Second, time.Second/2)
+		require.Eventually(t, cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 30*time.Second, time.Second/2)
 
 		require.NoError(t, exec.Command("kubectl", "-n", consumer.PodKey.Namespace, "exec", consumer.PodKey.Name, "--", "curl", "-sS", "http://localhost:8082/on").Run())
 
 		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(batchv1.Job), ns, drainerJobName)), 5*time.Minute, 30*time.Second)
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 5*time.Second, time.Second/2)
+		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 30*time.Second, time.Second/2)
 
 		pvc := common.Resource(new(corev1.PersistentVolumeClaim), ns, logging.Name+"-fluentd-buffer-"+fluentdReplicaName)
 		require.NoError(t, c.GetClient().Get(ctx, client.ObjectKeyFromObject(pvc), pvc))

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -314,11 +314,12 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		} else {
 			args = append(args, "--collector.disable-defaults", "--collector.filesystem")
 		}
+		customRunner := fmt.Sprintf("'./bin/node_exporter %v'", strings.Join(args, " "))
 		return &corev1.Container{
 			Name:            "buffer-metrics-sidecar",
 			Image:           r.Logging.Spec.FluentdSpec.BufferVolumeImage.RepositoryWithTag(),
 			ImagePullPolicy: corev1.PullPolicy(r.Logging.Spec.FluentdSpec.BufferVolumeImage.PullPolicy),
-			Args:            args,
+			Args:            []string{"--startup", customRunner},
 			Ports:           generatePortsBufferVolumeMetrics(r.Logging.Spec.FluentdSpec),
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -119,7 +119,7 @@ const (
 	DefaultFluentdImageTag                      = "v1.14.6-alpine-2"
 	DefaultFluentdBufferStorageVolumeName       = "fluentd-buffer"
 	DefaultFluentdDrainWatchImageRepository     = "ghcr.io/banzaicloud/fluentd-drain-watch"
-	DefaultFluentdDrainWatchImageTag            = "v0.0.1"
+	DefaultFluentdDrainWatchImageTag            = "v0.0.2"
 	DefaultFluentdDrainPauseImageRepository     = "k8s.gcr.io/pause"
 	DefaultFluentdDrainPauseImageTag            = "latest"
 	DefaultFluentdVolumeModeImageRepository     = "busybox"

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -126,8 +126,8 @@ const (
 	DefaultFluentdVolumeModeImageTag            = "latest"
 	DefaultFluentdConfigReloaderImageRepository = "jimmidyson/configmap-reload"
 	DefaultFluentdConfigReloaderImageTag        = "v0.4.0"
-	DefaultFluentdBufferVolumeImageRepository   = "quay.io/prometheus/node-exporter"
-	DefaultFluentdBufferVolumeImageTag          = "v1.1.2"
+	DefaultFluentdBufferVolumeImageRepository   = "ghcr.io/banzaicloud/custom-runner"
+	DefaultFluentdBufferVolumeImageTag          = "0.1.0"
 )
 
 // SetDefaults fills empty attributes


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #952 
| License         | Apache 2.0


### What's in this PR?
Custom runner env for drainer job's node exporter. This way the drain-watch.sh is able to shut down the container with a simple http call.

### Why?
Drainer job's node exporter didn't finish originally.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

