### PR TITLE
Allow containerOverrides for eventtailer and hosttailer to be set from logging-operator-logging values.

### DIFF
--- a/charts/logging-operator-logging/templates/eventtailer.yaml
+++ b/charts/logging-operator-logging/templates/eventtailer.yaml
@@ -7,6 +7,10 @@ spec:
   controlNamespace: {{ $.Values.controlNamespace | default $.Release.Namespace }}
   workloadOverrides:
     priorityClassName: system-node-critical
+{{- with .containerOverrides }}
+  containerOverrides:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 {{- with .pvc }}
   positionVolume:
     pvc:

--- a/charts/logging-operator-logging/templates/hosttailer.yaml
+++ b/charts/logging-operator-logging/templates/hosttailer.yaml
@@ -7,6 +7,10 @@ spec:
   enableRecreateWorkloadOnImmutableFieldChange: {{ $.Values.enableRecreateWorkloadOnImmutableFieldChange }}
   workloadOverrides:
     priorityClassName: system-node-critical
+{{- with .containerOverrides }}
+  containerOverrides:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 {{- with .fileTailers }}
   fileTailers:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This allows eventTailer and hostTailer container defaults to be overridden when using the logging-operator-logging chart values.yaml. 


### Why?
This is useful for overriding images for these pods for instance when running in an air gapped 
environment.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
