### PR TITLE
Add workloadOverrides control for eventtailer/hosttailer (Chart)

### DIFF
--- a/charts/logging-operator-logging/templates/eventtailer.yaml
+++ b/charts/logging-operator-logging/templates/eventtailer.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ .name | default "event-tailer" }}
 spec:
   controlNamespace: {{ $.Values.controlNamespace | default $.Release.Namespace }}
+{{- with .workloadOverrides }}
   workloadOverrides:
-    priorityClassName: system-node-critical
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .containerOverrides }}
   containerOverrides:
 {{- toYaml . | nindent 4 }}

--- a/charts/logging-operator-logging/templates/hosttailer.yaml
+++ b/charts/logging-operator-logging/templates/hosttailer.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ .name | default "hosttailer" }}
 spec:
   enableRecreateWorkloadOnImmutableFieldChange: {{ $.Values.enableRecreateWorkloadOnImmutableFieldChange }}
+{{- with .workloadOverrides }}
   workloadOverrides:
-    priorityClassName: system-node-critical
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .containerOverrides }}
   containerOverrides:
 {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add workloadOverrides control for eventtailer and hosttailer in helm templates in logging-operator-logging chart

### Why?
With old construction - can't control HostTailer DaemonSet
For example can't add tolerations for running DS pods on master nodes (Its important if u want get logs from master-nodes (k8s audit logs for example))

