### PR TITLE
feat: add storageclass to eventtailer chart

### DIFF
--- a/charts/logging-operator-logging/templates/eventtailer.yaml
+++ b/charts/logging-operator-logging/templates/eventtailer.yaml
@@ -20,7 +20,10 @@ spec:
         accessModes: {{ .accessModes | default (list "ReadWriteOnce") }}
         resources:
           requests:
-            storage: {{ .storage | default "1G" }}
+            storage: {{ .storage | default "1Gi" }}
         volumeMode: {{ .volumeMode | default "Filesystem" }}
+{{- with .storageClass }}
+        storageClass: {{ .storageClass }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logging-operator-logging/values.yaml
+++ b/charts/logging-operator-logging/values.yaml
@@ -104,7 +104,8 @@ eventTailer: {}
   #   accessModes:
   #     - ReadWriteOnce
   #   volumeMode: Filesystem
-  #   storage: 1G
+  #   storage: 1Gi
+  #   storageClass: standard
 
 # HostTailer config
 hostTailer: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add the storageClass option to specify the PVC provisionner in the EventTailer chart entry.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This allows theuse of a non default storage class.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
