### PR TITLE
Fix Fluentd warning "parameter 'data_stream_enable' is not used"

### DIFF
--- a/pkg/sdk/logging/model/output/elasticsearch.go
+++ b/pkg/sdk/logging/model/output/elasticsearch.go
@@ -242,7 +242,7 @@ type ElasticsearchOutput struct {
 	// Specify whether overwriting ilm policy or not.
 	IlmPolicyOverwrite bool `json:"ilm_policy_overwrite,omitempty"`
 	// Use @type elasticsearch_data_stream
-	DataStreamEnable *bool `json:"data_stream_enable,omitempty"`
+	DataStreamEnable *bool `json:"data_stream_enable,omitempty" plugin:"hidden"`
 	// You can specify Elasticsearch data stream name by this parameter. This parameter is mandatory for elasticsearch_data_stream. There are some limitations about naming rule. For more details https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html#indices-create-data-stream-api-path-params
 	DataStreamName string `json:"data_stream_name,omitempty"`
 	// Specify an existing index template for the data stream. If not present, a new template is created and named after the data stream. (default: data_stream_name) Further details here https://github.com/uken/fluent-plugin-elasticsearch#configuration---elasticsearch-output-data-stream

--- a/pkg/sdk/logging/model/output/elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/elasticsearch_test.go
@@ -66,3 +66,50 @@ buffer:
 	test := render.NewOutputPluginTest(t, es)
 	test.DiffResult(expected)
 }
+
+func TestElasticSearchDataStream(t *testing.T) {
+	CONFIG := []byte(`
+host: elasticsearch-elasticsearch-cluster.default.svc.cluster.local
+port: 9200
+scheme: https
+ssl_version: TLSv1_2
+ssl_verify: false
+data_stream_enable: true
+data_stream_name: test-ds
+buffer:
+  timekey: 1m
+  timekey_wait: 30s
+  timekey_use_utc: true
+
+`)
+	expected := `
+  <match **>
+    @type elasticsearch_data_stream
+    @id test
+    data_stream_name test-ds
+    exception_backup true
+    fail_on_putting_template_retry_exceed true
+    host elasticsearch-elasticsearch-cluster.default.svc.cluster.local
+    port 9200
+    reload_connections true
+    scheme https
+    ssl_verify false
+    ssl_version TLSv1_2
+    utc_index true
+    verify_es_version_at_startup true
+    <buffer tag,time>
+      @type file
+      chunk_limit_size 8MB
+      path /buffers/test.*.buffer
+      retry_forever true
+      timekey 1m
+      timekey_use_utc true
+      timekey_wait 30s
+    </buffer>
+  </match>
+`
+	es := &output.ElasticsearchOutput{}
+	require.NoError(t, yaml.Unmarshal(CONFIG, es))
+	test := render.NewOutputPluginTest(t, es)
+	test.DiffResult(expected)
+}


### PR DESCRIPTION
  | Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Making the Elasticsarch's output attribute `data_stream_enable` hidden to make sure it is not rendered into the Fluentd configuration file.


### Why?
Attribute `data_stream_enable` is artificial / only used by the logging operator. It is not something Fluentd knows about as the data stream usage is denoted by different `@type` (`elasticsearch_data_stream` vs `elasticsearch`).

The extra attribute does not really break anything, but Fluentd prints ugly warning for each output using data stream.
```
2022-07-29 13:14:35 +0000 [warn]: parameter 'data_stream_enable' in <match **>
  @type elasticsearch_data_stream
  @id ...
  data_stream_enable true
  data_stream_name "logs"
  ....
</match> is not used.
```
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
