### PR TITLE
Fix failing TestElasticSearchDataStream

### DIFF
--- a/pkg/sdk/logging/model/output/elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/elasticsearch_test.go
@@ -88,6 +88,7 @@ buffer:
     @id test
     data_stream_name test-ds
     exception_backup true
+    fail_on_detecting_es_version_retry_exceed true
     fail_on_putting_template_retry_exceed true
     host elasticsearch-elasticsearch-cluster.default.svc.cluster.local
     port 9200


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes (bug in test)
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Simple fix for a failing test. Probably caused by a merge of https://github.com/banzaicloud/logging-operator/commit/20a3f939ae9d95d01c4fb75cf2444089d1a6935c.

### Additional context

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
