### PR TITLE
fluentd serviceMonitor - support aggregated_metrics scrape path

### DIFF
--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -91,6 +91,10 @@ func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.Desired
 				objectMetadata.Labels[k] = v
 			}
 		}
+		metricScrapePath := r.Logging.Spec.FluentdSpec.Metrics.Path
+		if r.Logging.Spec.FluentdSpec.Workers > 1 {
+			metricScrapePath = "/aggregated_metrics"
+		}
 
 		return &v1.ServiceMonitor{
 			ObjectMeta: objectMetadata,
@@ -100,7 +104,7 @@ func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.Desired
 				PodTargetLabels: nil,
 				Endpoints: []v1.Endpoint{{
 					Port:                 "http-metrics",
-					Path:                 r.Logging.Spec.FluentdSpec.Metrics.Path,
+					Path:                 metricScrapePath,
 					Interval:             r.Logging.Spec.FluentdSpec.Metrics.Interval,
 					ScrapeTimeout:        r.Logging.Spec.FluentdSpec.Metrics.Timeout,
 					HonorLabels:          r.Logging.Spec.FluentdSpec.Metrics.ServiceMonitorConfig.HonorLabels,


### PR DESCRIPTION
https://github.com/banzaicloud/logging-operator/issues/1110

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1110 
| License         | Apache 2.0


### What's in this PR?
Change prometheus serviceMonitor scrape path if number of workers is greater than one.

### Why?
See #1110 


### Additional context
I debated putting it behind a flag but I can't think of a scenario where anyone using multi-workers wouldn't want to get metrics for all worker processes.

### Checklist
- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)


This is my quick, hacky attempt to fix #1110, feel free to trash or close if better approach desired.