### PR TITLE
fix: skip errored flows when building the routes

### DIFF
--- a/pkg/resources/model/system.go
+++ b/pkg/resources/model/system.go
@@ -80,7 +80,8 @@ func CreateSystem(resources LoggingResources, secrets SecretLoaderFactory, logge
 		flow, err := FlowForFlow(flowCr, resources.ClusterOutputs, resources.Outputs, secrets)
 		if err != nil {
 			if logging.Spec.SkipInvalidResources {
-				logger.Error(err, "Flow contains errors.")
+				logger.Error(err, "Flow contains errors, skipping.")
+				continue
 			} else {
 				return nil, err
 			}
@@ -94,7 +95,8 @@ func CreateSystem(resources LoggingResources, secrets SecretLoaderFactory, logge
 		flow, err := FlowForClusterFlow(flowCr, resources.ClusterOutputs, secrets)
 		if err != nil {
 			if logging.Spec.SkipInvalidResources {
-				logger.Error(err, "ClusterFlow contains errors.")
+				logger.Error(err, "ClusterFlow contains errors, skipping.")
+				continue
 			} else {
 				return nil, err
 			}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets | fixes #615
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Flows in error (referencing non existing output for example) should be skipped when building routing configuration.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently, errored flows are kept in the fluentd config, which makes the configcheck fails and the world stops until the source resources are fixed.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This causes noisy neighborhood issues in a multi-tenant world where users control their flow/output and admins manages the logging infra. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Discuss the changes
- [ ] Check if it solves the issue
