### PR TITLE
fix: only install PodSecurityPolicy if the API is available

### DIFF
--- a/charts/logging-operator/templates/psp.yaml
+++ b/charts/logging-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.rbac.enabled .Values.rbac.psp.enabled }}
+{{ if and .Values.rbac.enabled .Values.rbac.psp.enabled  (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | Closes #1077 
| License         | Apache 2.0


### What's in this PR?
This PR adds a check for the PodSecurityPolicy API in the chart, and avoids trying to use that API if it is not available. This API is [removed in k8s v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125).


### Additional context
I tested this in k8s v1.22 where the PSP is still installed, and in v1.25 where the PSP is not installed anymore. This makes the chart usable in k8s v1.25+.


### Checklist

- [x] Related Helm chart(s) updated (if needed)
