### PR TITLE
handle flush error in cached RESTMapper constructor

### DIFF
--- a/pkg/k8sutil/cache.go
+++ b/pkg/k8sutil/cache.go
@@ -34,7 +34,9 @@ func NewCached(config *rest.Config) (meta.RESTMapper, error) {
 			return apiutil.NewDiscoveryRESTMapper(config)
 		},
 	}
-	c.flush()
+	if err := c.flush(); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #881
| License         | Apache 2.0


### What's in this PR?
Handle flush error in cached RESTMapper constructor.
