### PR TITLE
Move persist file next to buffers

### DIFF
--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -89,7 +89,7 @@ func syslogNGContainer(spec *v1beta1.SyslogNGSpec) corev1.Container {
 		Args: []string{
 			"--cfgfile=" + configDir + "/" + configKey,
 			"--control=" + socketPath,
-			"--persist-file=" + bufferPath + "/syslog-ng.persist",
+			"--persist-file=" + filepath.Join(bufferPath, "/syslog-ng.persist"),
 			"--no-caps",
 			"-Fe",
 		},

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -89,6 +89,7 @@ func syslogNGContainer(spec *v1beta1.SyslogNGSpec) corev1.Container {
 		Args: []string{
 			"--cfgfile=" + configDir + "/" + configKey,
 			"--control=" + socketPath,
+			"--persist-file=" + bufferPath + "/syslog-ng.persist",
 			"--no-caps",
 			"-Fe",
 		},


### PR DESCRIPTION
Syslog-ng stores persist information (like buffer file path) in a persist file. In the case this file is not persisted Pod restart may spawn new buffer files and ignore old files. To prevent this we moved the persist file next to the buffers.